### PR TITLE
Fixed a bug in MultipleInputSinkStrat

### DIFF
--- a/src/sink/model.jl
+++ b/src/sink/model.jl
@@ -13,8 +13,8 @@ Creates the following additional variables for **ALL** [`PeriodDemandSink`](@ref
     can consist of multiple operational periods.
 """
 function EMB.variables_node(m, 𝒩ˢⁱⁿᵏ::Vector{<:AbstractPeriodDemandSink}, 𝒯, ::EnergyModel)
-    @variable(m, demand_sink_surplus[n ∈ 𝒩ˢⁱⁿᵏ, i=1:number_of_periods(n, 𝒯)] >= 0)
-    @variable(m, demand_sink_deficit[n ∈ 𝒩ˢⁱⁿᵏ, i=1:number_of_periods(n, 𝒯)] >= 0)
+    @variable(m, demand_sink_surplus[n ∈ 𝒩ˢⁱⁿᵏ, i=1:number_of_periods(n, 𝒯)] ≥ 0)
+    @variable(m, demand_sink_deficit[n ∈ 𝒩ˢⁱⁿᵏ, i=1:number_of_periods(n, 𝒯)] ≥ 0)
 end
 
 """
@@ -36,11 +36,10 @@ function EMB.variables_node(
 
     # Declaration of the required subsets.
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-    𝒫 = unique([p for n ∈ 𝒩 for p ∈ inputs(n)])
 
-    @variable(m, 0 ≤ input_frac_strat[𝒩, 𝒯ᴵⁿᵛ, 𝒫] ≤ 1)
-    @variable(m, sink_surplus_p[𝒩, 𝒯, 𝒫] >= 0)
-    @variable(m, sink_deficit_p[𝒩, 𝒯, 𝒫] >= 0)
+    @variable(m, 0 ≤ input_frac_strat[n ∈ 𝒩, 𝒯ᴵⁿᵛ, inputs(n)] ≤ 1)
+    @variable(m, sink_surplus_p[n ∈ 𝒩, 𝒯, inputs(n)] ≥ 0)
+    @variable(m, sink_deficit_p[n ∈ 𝒩, 𝒯, inputs(n)] ≥ 0)
 end
 
 """
@@ -53,9 +52,8 @@ function EMB.variables_node(m, 𝒩::Vector{BinaryMultipleInputSinkStrat}, 𝒯,
 
     # Declaration of the required subsets.
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-    𝒫 = unique([p for n ∈ 𝒩 for p ∈ inputs(n)])
 
-    for n ∈ 𝒩, t_inv ∈ 𝒯ᴵⁿᵛ, p ∈ 𝒫
+    for n ∈ 𝒩, t_inv ∈ 𝒯ᴵⁿᵛ, p ∈ inputs(n)
         set_binary(m[:input_frac_strat][n, t_inv, p])
     end
 end
@@ -77,7 +75,7 @@ The individual time periods which allow for load shifting are declared by the pa
 """
 function EMB.variables_node(m, 𝒩ᴸˢ::Vector{<:LoadShiftingNode}, 𝒯, ::EnergyModel)
     ops = collect(𝒯)
-    @variable(m, load_shift_from[n ∈ 𝒩ᴸˢ, ops[n.load_shift_times]] >= 0, Int)
-    @variable(m, load_shift_to[n ∈ 𝒩ᴸˢ, ops[n.load_shift_times]] >= 0, Int)
+    @variable(m, load_shift_from[n ∈ 𝒩ᴸˢ, ops[n.load_shift_times]] ≥ 0, Int)
+    @variable(m, load_shift_to[n ∈ 𝒩ᴸˢ, ops[n.load_shift_times]] ≥ 0, Int)
     @variable(m, load_shifted[𝒩ᴸˢ, 𝒯])
 end

--- a/test/sink/test_BinaryMultipleInputSinkStrat.jl
+++ b/test/sink/test_BinaryMultipleInputSinkStrat.jl
@@ -1,6 +1,7 @@
 
 NG = ResourceCarrier("NG", 0.2)
 H2 = ResourceCarrier("H2", 0.0)
+power = ResourceCarrier("Power", 0.0)
 CO2 = ResourceEmit("CO2", 1.0)
 
 source_1 = RefSource(
@@ -17,21 +18,37 @@ source_2 = RefSource(
     FixedProfile(0),
     Dict(H2 => 1),
 )
-
-sink = BinaryMultipleInputSinkStrat(
+source_3 = RefSource(
     3,
+    FixedProfile(5),
+    StrategicProfile([10, 5]),
+    FixedProfile(0),
+    Dict(power => 1),
+)
+
+sink_1 = BinaryMultipleInputSinkStrat(
+    4,
     FixedProfile(8),
     Dict(:surplus => FixedProfile(4), :deficit => FixedProfile(10)),
     Dict(NG => 1.2, H2 => 1.1),
 )
+sink_2 = BinaryMultipleInputSinkStrat(
+    5,
+    FixedProfile(8),
+    Dict(:surplus => FixedProfile(4), :deficit => FixedProfile(10)),
+    Dict(NG => 1.2, power => 1.0),
+)
 
 # Creating and solving the model
-𝒫 = [NG, H2, CO2]
+𝒫 = [NG, H2, CO2, power]
 𝒯 = TwoLevel(2, 2, SimpleTimes(5, 2))
 𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-𝒩 = [source_1, source_2, sink]
-ℒ = [Direct(13, source_1, sink), Direct(23, source_2, sink)]
+𝒩 = [source_1, source_2, source_3, sink_1, sink_2]
+ℒ = [
+    Direct(13, source_1, sink_1), Direct(23, source_2, sink_1),
+    Direct(13, source_1, sink_2), Direct(23, source_3, sink_2),
+]
 model = OperationalModel(
     Dict(CO2 => FixedProfile(100)),
     Dict(CO2 => FixedProfile(100)),
@@ -40,8 +57,23 @@ model = OperationalModel(
 case = Dict(:T => 𝒯, :nodes => 𝒩, :links => ℒ, :products => 𝒫)
 m = EMB.run_model(case, model, OPTIMIZER)
 
+# Test the correct variable definition and that the variable is a sparse axis array
+for var ∈ [:input_frac_strat, :sink_surplus_p, :sink_deficit_p]
+    if var == :input_frac_strat
+        t = first(𝒯ᴵⁿᵛ)
+    else
+        t = first(𝒯)
+    end
+    @test haskey(m[var][sink_1, t, :], NG)
+    @test haskey(m[var][sink_1, t, :], H2)
+    @test !haskey(m[var][sink_1, t, :], power)
+    @test haskey(m[var][sink_2, t, :], NG)
+    @test !haskey(m[var][sink_2, t, :], H2)
+    @test haskey(m[var][sink_2, t, :], power)
+end
+
 # Testing the correct source usage
-𝒫ⁱⁿ = inputs(sink)
+𝒫ⁱⁿ = inputs(sink_1)
 for t_inv ∈ 𝒯ᴵⁿᵛ
     if t_inv.sp == 1
         @test all(value.(m[:flow_out][source_1, t, NG]) > 0 for t ∈ t_inv)
@@ -49,22 +81,22 @@ for t_inv ∈ 𝒯ᴵⁿᵛ
     else
         @test all(value.(m[:flow_out][source_1, t, NG]) == 0 for t ∈ t_inv)
         @test all(value.(m[:flow_out][source_2, t, H2]) > 0 for t ∈ t_inv)
-        @test all(value.(m[:sink_deficit][sink, t]) > 0 for t ∈ t_inv)
+        @test all(value.(m[:sink_deficit][sink_1, t]) > 0 for t ∈ t_inv)
     end
 end
 @test all(
-    sum(value.(m[:flow_in][sink, t, p])/inputs(sink, p) for p ∈ 𝒫ⁱⁿ) ≈
-    value.(m[:cap_use][sink, t]) for t ∈ 𝒯, atol ∈ TEST_ATOL
+    sum(value.(m[:flow_in][sink_1, t, p])/inputs(sink_1, p) for p ∈ 𝒫ⁱⁿ) ≈
+    value.(m[:cap_use][sink_1, t]) for t ∈ 𝒯, atol ∈ TEST_ATOL
 )
 
 # Test that the binary declaration is working
 @test all(
-    is_binary(m[:input_frac_strat][sink, t_inv, p]) for
+    is_binary(m[:input_frac_strat][sink_1, t_inv, p]) for
     t_inv ∈ 𝒯ᴵⁿᵛ, p ∈ 𝒫ⁱⁿ
 )
 
 # Test that the sum constraint in all investment periods is fulfilled
 @test all(
-    sum(value.(m[:input_frac_strat][sink, t_inv, p]) for p ∈ 𝒫ⁱⁿ) == 1 for
+    sum(value.(m[:input_frac_strat][sink_1, t_inv, p]) for p ∈ 𝒫ⁱⁿ) == 1 for
     t_inv ∈ 𝒯ᴵⁿᵛ
 )

--- a/test/sink/test_ContinuousMultipleInputSinkStrat.jl
+++ b/test/sink/test_ContinuousMultipleInputSinkStrat.jl
@@ -17,20 +17,37 @@ source_2 = RefSource(
     FixedProfile(0),
     Dict(H2 => 1),
 )
-
-sink = ContinuousMultipleInputSinkStrat(
+source_3 = RefSource(
     3,
+    FixedProfile(5),
+    StrategicProfile([10, 5]),
+    FixedProfile(0),
+    Dict(power => 1),
+)
+
+sink_1 = ContinuousMultipleInputSinkStrat(
+    4,
     FixedProfile(8),
     Dict(:surplus => FixedProfile(4), :deficit => FixedProfile(100)),
     Dict(NG => 1.2, H2 => 1.1),
 )
+sink_2 = ContinuousMultipleInputSinkStrat(
+    5,
+    FixedProfile(8),
+    Dict(:surplus => FixedProfile(4), :deficit => FixedProfile(100)),
+    Dict(NG => 1.2, power => 1.0),
+)
 
 # Creating and solving the model
-𝒫 = [NG, H2, CO2]
+𝒫 = [NG, H2, CO2, power]
 𝒯 = TwoLevel(2, 2, SimpleTimes(5, 2))
 𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-𝒩 = [source_1, source_2, sink]
-ℒ = [Direct(13, source_1, sink), Direct(23, source_2, sink)]
+
+𝒩 = [source_1, source_2, source_3, sink_1, sink_2]
+ℒ = [
+    Direct(13, source_1, sink_1), Direct(23, source_2, sink_1),
+    Direct(13, source_1, sink_2), Direct(23, source_3, sink_2),
+]
 model = OperationalModel(
     Dict(CO2 => FixedProfile(100)),
     Dict(CO2 => FixedProfile(100)),
@@ -40,24 +57,39 @@ model = OperationalModel(
 case = Dict(:T => 𝒯, :nodes => 𝒩, :links => ℒ, :products => 𝒫)
 m = EMB.run_model(case, model, OPTIMIZER)
 
+# Test the correct variable definition and that the variable is a sparse axis array
+for var ∈ [:input_frac_strat, :sink_surplus_p, :sink_deficit_p]
+    if var == :input_frac_strat
+        t = first(𝒯ᴵⁿᵛ)
+    else
+        t = first(𝒯)
+    end
+    @test haskey(m[var][sink_1, t, :], NG)
+    @test haskey(m[var][sink_1, t, :], H2)
+    @test !haskey(m[var][sink_1, t, :], power)
+    @test haskey(m[var][sink_2, t, :], NG)
+    @test !haskey(m[var][sink_2, t, :], H2)
+    @test haskey(m[var][sink_2, t, :], power)
+end
+
 # Testing the correct source usage
-𝒫ⁱⁿ = inputs(sink)
+𝒫ⁱⁿ = inputs(sink_1)
 for t_inv ∈ 𝒯ᴵⁿᵛ
     if t_inv.sp == 1
-        @test all(value.(m[:flow_out][source_1, t, NG]) > 0 for t ∈ t_inv)
-        @test all(value.(m[:flow_out][source_2, t, H2]) == 0 for t ∈ t_inv)
+        @test all(value.(m[:flow_out][source_1, t, NG]) ≈ 10 for t ∈ t_inv)
+        @test all(value.(m[:flow_out][source_2, t, H2]) ≈ 2.9333333 for t ∈ t_inv)
     else
-        @test all(value.(m[:flow_out][source_1, t, NG]) > 0 for t ∈ t_inv)
-        @test all(value.(m[:flow_out][source_2, t, H2]) > 0 for t ∈ t_inv)
+        @test all(value.(m[:flow_out][source_1, t, NG]) ≈ 5 for t ∈ t_inv)
+        @test all(value.(m[:flow_out][source_2, t, H2]) ≈ 4 for t ∈ t_inv)
     end
 end
 @test all(
-    sum(value.(m[:flow_in][sink, t, p])/inputs(sink, p) for p ∈ 𝒫ⁱⁿ) ≈
-    value.(m[:cap_use][sink, t]) for t ∈ 𝒯, atol ∈ TEST_ATOL
+    sum(value.(m[:flow_in][sink_1, t, p])/inputs(sink_1, p) for p ∈ 𝒫ⁱⁿ) ≈
+    value.(m[:cap_use][sink_1, t]) for t ∈ 𝒯, atol ∈ TEST_ATOL
 )
 
 # Test that the sum constraint in all investment periods is fulfilled
 @test all(
-    sum(value.(m[:input_frac_strat][sink, t_inv, p]) for p ∈ 𝒫ⁱⁿ) == 1 for
+    sum(value.(m[:input_frac_strat][sink_1, t_inv, p]) for p ∈ 𝒫ⁱⁿ) == 1 for
     t_inv ∈ 𝒯ᴵⁿᵛ
 )


### PR DESCRIPTION
The variables created for this type are potentially unconstrained due not defining them as sparse. This can lead to a situation in which an unconstrained `sink_surplus_p` results in an unbound objective function given certain deficit and surplus values (if the surplus is negative).