### PR TITLE
Adjustment to EMB v0.9

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,25 @@
 # Release notes
 
+## Version 0.2.9 (2025-07-08)
+
+* Adjusted to [`EnergyModelsBase` v0.9.0](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.0):
+  * Increased version number for EMB.
+  * Replaced `variables_node` with `variables_element`.
+
+### Bugfix
+
+* Fixed a bug in `MultipleInputStrat` nodes:
+  * The variables were declared over all input resources of a nodes of this type.
+  * As a consequence, unconstrained variables were declared when multiple nodes with differing inputs were included.
+  * In the worst case, this could lead to an unbound problem if the surplus penalty was negative.
+
 ## Version 0.2.8 (2025-07-04)
 
 ### Public release on GitHub
 
 * Released the exisiting version so that case studies in the project [FLEX4FACT](https://flex4fact.eu/) are running without any problems.
 * Release depends on old versions of `EnergyModelsBase`.
-* It is planned to update the model to the latest version within a short period of time
+* It is planned to update the model to the latest version within a short period of time.
 
 ## Version 0.2.7 (2025-01-14)
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsFlex"
 uuid = "a81b9388-333d-4b63-81f2-910b060b544c"
-authors = ["Sigrid Aunsmo, Sigmund Eggen Holm, Jon Vegard Venås, and  Per Åslid"]
-version = "0.2.8"
+authors = ["Sigrid Aunsmo, Sigmund Eggen Holm, Jon Vegard Venås, and Per Åslid"]
+version = "0.2.9"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
@@ -10,8 +10,8 @@ JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"
 
 [compat]
-EnergyModelsBase = "0.8.3"
-EnergyModelsRenewableProducers = "0.6.4"
+EnergyModelsBase = "0.9"
+EnergyModelsRenewableProducers = "0.6.5"
 JuMP = "1.23"
 TimeStruct = "0.9"
 julia = "1.10"

--- a/docs/src/library/internals/methods-EMB.md
+++ b/docs/src/library/internals/methods-EMB.md
@@ -9,7 +9,7 @@ Pages = ["methods-EMB.md"]
 ## [Extension methods](@id lib-int-met_emb-ext)
 
 ```@docs
-EnergyModelsBase.variables_node
+EnergyModelsBase.variables_element
 ```
 
 ## [Constraint methods](@id lib-int-met_emb-con)

--- a/docs/src/nodes/sink/multipleinputsinkstrat.md
+++ b/docs/src/nodes/sink/multipleinputsinkstrat.md
@@ -89,7 +89,7 @@ It does not add any additional variables.
 
 #### [Additional variables](@id nodes-mul_in_sink_strat-math-add)
 
-[`AbstractMultipleInputSinkStrat`](@ref EnergyModelsFlex.AbstractMultipleInputSinkStrat) nodes declare in addition several variables through dispatching on the method [`EnergyModelsBase.variables_node()`](@ref) for including constraints for deficits and surplus for individual resources as well as what the fraction satisfied by each resource.
+[`AbstractMultipleInputSinkStrat`](@ref EnergyModelsFlex.AbstractMultipleInputSinkStrat) nodes declare in addition several variables through dispatching on the method [`EnergyModelsBase.variables_element()`](@ref) for including constraints for deficits and surplus for individual resources as well as what the fraction satisfied by each resource.
 These variables are for an [`AbstractMultipleInputSinkStrat`](@ref EnergyModelsFlex.AbstractMultipleInputSinkStrat) node ``n`` in operational period ``t``:
 
 - ``\texttt{input\_frac\_strat}[n, t_{inv}, p]``:\

--- a/docs/src/nodes/sink/perioddemand.md
+++ b/docs/src/nodes/sink/perioddemand.md
@@ -104,7 +104,7 @@ The variables include:
 
 #### [Additional variables](@id nodes-perioddemandsink-math-add)
 
-[`AbstractPeriodDemandSink`](@ref EnergyModelsFlex.AbstractPeriodDemandSink) nodes declare in addition several variables through dispatching on the method [`EnergyModelsBase.variables_node()`](@ref) for including constraints for deficits and surplus for individual resources as well as what the fraction satisfied by each resource.
+[`AbstractPeriodDemandSink`](@ref EnergyModelsFlex.AbstractPeriodDemandSink) nodes declare in addition several variables through dispatching on the method [`EnergyModelsBase.variables_element()`](@ref) for including constraints for deficits and surplus for individual resources as well as what the fraction satisfied by each resource.
 These variables are for a [`AbstractPeriodDemandSink`](@ref EnergyModelsFlex.AbstractPeriodDemandSink) node ``n`` in demand periods ``i``:
 
 - ``\texttt{demand\_sink\_surplus}[n, i]``:\

--- a/examples/flexible_demand.jl
+++ b/examples/flexible_demand.jl
@@ -18,10 +18,11 @@ using PrettyTables
 Power = ResourceCarrier("Power", 0)
 Product = ResourceCarrier("Product", 0)
 CO2 = ResourceEmit("CO2", 0)
+𝒫 = [Power, Product]
 
 # Define a timestructure for a single week.
 # The week is modelled with hourly resolution.
-T = TwoLevel(1, 1, SimpleTimes(7 * 24, 1))
+𝒯 = TwoLevel(1, 1, SimpleTimes(7 * 24, 1))
 
 # Some arbitrary electricity prices. Note we let the energy be free in the weekend.
 # This would be a huge incentive to produce during the weekend, if we allowed the
@@ -72,9 +73,9 @@ line = MinUpDownTimeNode(
 )
 
 # Define the simple energy system
-nodes = [grid, line, demand]
-links = [Direct("grid-line", grid, line), Direct("line-demand", line, demand)]
-case = Dict(:T => T, :nodes => nodes, :products => [Power, Product], :links => links)
+𝒩 = [grid, line, demand]
+ℒ = [Direct("grid-line", grid, line), Direct("line-demand", line, demand)]
+case = Case(𝒯, 𝒫, [𝒩, ℒ])
 
 # Define as operational energy model
 modeltype = OperationalModel(
@@ -93,7 +94,7 @@ m = run_model(case, modeltype, HiGHS.Optimizer)
 table = JuMP.Containers.rowtable(value, m[:cap_use]; header = [:Node, :TimePeriod, :CapUse])
 
 # Filter only for `Node == line`
-line = case[:nodes][2]
+line = get_nodes(case)[2]
 filtered = filter(row -> row.Node == line, table)
 
 # Display the filtered table with the resulting optimal production.

--- a/src/network/model.jl
+++ b/src/network/model.jl
@@ -1,5 +1,5 @@
 """
-    EMB.variables_node(m, 𝒩uc::Vector{UnitCommitmentNode}, 𝒯, ::EnergyModel)
+    EMB.variables_element(m, 𝒩uc::Vector{UnitCommitmentNode}, 𝒯, ::EnergyModel)
 
 # Arguments
 - `m`: The optimization model.
@@ -12,7 +12,7 @@
 - `offswitch[n, t]`: Binary variable indicating the node is switched off.
 - `on_off[n, t]`: Binary variable indicating the node's on/off state.
 """
-function EMB.variables_node(m, 𝒩uc::Vector{UnitCommitmentNode}, 𝒯, ::EnergyModel)
+function EMB.variables_element(m, 𝒩uc::Vector{UnitCommitmentNode}, 𝒯, ::EnergyModel)
     @variable(m, onswitch[𝒩uc, 𝒯], Bin)
     @variable(m, offswitch[𝒩uc, 𝒯], Bin)
     @variable(m, on_off[𝒩uc, 𝒯], Bin)

--- a/src/sink/model.jl
+++ b/src/sink/model.jl
@@ -1,5 +1,5 @@
 """
-    EMB.variables_node(m, 𝒩ˢⁱⁿᵏ::Vector{<:AbstractPeriodDemandSink}, 𝒯, ::EnergyModel)
+    EMB.variables_element(m, 𝒩ˢⁱⁿᵏ::Vector{<:AbstractPeriodDemandSink}, 𝒯, ::EnergyModel)
 
 Creates the following additional variables for **ALL** [`PeriodDemandSink`](@ref) nodes:
 - `demand_sink_surplus[n, i]` is a non-negative variable indicating a surplus in demand in
@@ -12,13 +12,18 @@ Creates the following additional variables for **ALL** [`PeriodDemandSink`](@ref
     from `TimeStruct`. Instead, it is a period in which the demand must be satisfied. A period
     can consist of multiple operational periods.
 """
-function EMB.variables_node(m, 𝒩ˢⁱⁿᵏ::Vector{<:AbstractPeriodDemandSink}, 𝒯, ::EnergyModel)
+function EMB.variables_element(
+    m,
+    𝒩ˢⁱⁿᵏ::Vector{<:AbstractPeriodDemandSink},
+    𝒯,
+    ::EnergyModel,
+)
     @variable(m, demand_sink_surplus[n ∈ 𝒩ˢⁱⁿᵏ, i=1:number_of_periods(n, 𝒯)] ≥ 0)
     @variable(m, demand_sink_deficit[n ∈ 𝒩ˢⁱⁿᵏ, i=1:number_of_periods(n, 𝒯)] ≥ 0)
 end
 
 """
-    EMB.variables_node(m, 𝒩::Vector{<:AbstractMultipleInputSinkStrat}, 𝒯, ::EnergyModel)
+    EMB.variables_element(m, 𝒩::Vector{<:AbstractMultipleInputSinkStrat}, 𝒯, ::EnergyModel)
 
 Creates the following additional variables for **ALL** [`AbstractMultipleInputSinkStrat`](@ref)
 subtypes:
@@ -27,7 +32,7 @@ subtypes:
 - `sink_surplus_p[n, t, p]` is the surplus of resource `p` in operational period `t`.
 - `sink_deficit_p[n, t, p]` is the deficit of resource `p` in operational period `t`.
 """
-function EMB.variables_node(
+function EMB.variables_element(
     m,
     𝒩::Vector{<:AbstractMultipleInputSinkStrat},
     𝒯,
@@ -43,12 +48,12 @@ function EMB.variables_node(
 end
 
 """
-    EMB.variables_node(m, 𝒩::Vector{BinaryMultipleInputSinkStrat}, 𝒯, ::EnergyModel)
+    EMB.variables_element(m, 𝒩::Vector{BinaryMultipleInputSinkStrat}, 𝒯, ::EnergyModel)
 
 Modifies the variable `input_frac_strat[n, t_inv, p]` of [`BinaryMultipleInputSinkStrat`](@ref)
 to be binary to not allow fuel switching within a strategic period.
 """
-function EMB.variables_node(m, 𝒩::Vector{BinaryMultipleInputSinkStrat}, 𝒯, ::EnergyModel)
+function EMB.variables_element(m, 𝒩::Vector{BinaryMultipleInputSinkStrat}, 𝒯, ::EnergyModel)
 
     # Declaration of the required subsets.
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
@@ -59,7 +64,7 @@ function EMB.variables_node(m, 𝒩::Vector{BinaryMultipleInputSinkStrat}, 𝒯,
 end
 
 """
-    EMB.variables_node(m, 𝒩ᴸˢ::Vector{<:LoadShiftingNode}, 𝒯, ::EnergyModel)
+    EMB.variables_element(m, 𝒩ᴸˢ::Vector{<:LoadShiftingNode}, 𝒯, ::EnergyModel)
 
 Creates the following additional variables for **ALL** [`LoadShiftingNode`](@ref) nodes.
 - `load_shift_from[n, t]` is an integer variable for how many batches are shifted away from
@@ -73,7 +78,7 @@ Creates the following additional variables for **ALL** [`LoadShiftingNode`](@ref
 The individual time periods which allow for load shifting are declared by the parameter
 `load_shift_times`.
 """
-function EMB.variables_node(m, 𝒩ᴸˢ::Vector{<:LoadShiftingNode}, 𝒯, ::EnergyModel)
+function EMB.variables_element(m, 𝒩ᴸˢ::Vector{<:LoadShiftingNode}, 𝒯, ::EnergyModel)
     ops = collect(𝒯)
     @variable(m, load_shift_from[n ∈ 𝒩ᴸˢ, ops[n.load_shift_times]] ≥ 0, Int)
     @variable(m, load_shift_to[n ∈ 𝒩ᴸˢ, ops[n.load_shift_times]] ≥ 0, Int)

--- a/test/network/test_ActivationCostNode.jl
+++ b/test/network/test_ActivationCostNode.jl
@@ -57,8 +57,7 @@ function act_node_test_case(
     ]
 
     # Create the case and modeltype
-    case = Dict(:T => 𝒯, :nodes => 𝒩, :links => ℒ, :products => 𝒫)
-    # case = Case(𝒯, 𝒫, [𝒩, ℒ], [[get_nodes, get_links]])
+    case = Case(𝒯, 𝒫, [𝒩, ℒ])
     modeltype = OperationalModel(
         Dict(co2 => FixedProfile(10)),
         Dict(co2 => FixedProfile(0)),
@@ -109,8 +108,8 @@ end
     m, case, modeltype = act_node_test_case(𝒯; demand)
 
     # Extract the values
-    𝒯 = case[:T]
-    𝒩 = case[:nodes]
+    𝒯 = get_time_struct(case)
+    𝒩 = get_nodes(case)
     acn = 𝒩[3]
 
     # Test that the capacity is limited

--- a/test/network/test_Combustion.jl
+++ b/test/network/test_Combustion.jl
@@ -4,6 +4,7 @@ H2 = ResourceCarrier("H2", 0.0)
 gas_LHV = ResourceCarrier("gas LHV", 0)
 Heat = ResourceCarrier("Reusable excess heat", 0)
 CO2 = ResourceEmit("CO2", 1.0)
+𝒫 = [NG, H2, gas_LHV, Heat, CO2]
 
 source_1 = RefSource(
     1,
@@ -48,12 +49,11 @@ reusable_excess_heat = RefSink(
 )
 
 # Creating and solving the model
-resources = [NG, H2, gas_LHV, Heat, CO2]
 𝒯 = TwoLevel(2, 2, SimpleTimes(5, 2))
 𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-nodes = [source_1, source_2, combustion, sink, reusable_excess_heat]
-links = [
+𝒩 = [source_1, source_2, combustion, sink, reusable_excess_heat]
+ℒ = [
     Direct(13, source_1, combustion),
     Direct(23, source_2, combustion),
     Direct(34, combustion, sink),
@@ -64,7 +64,7 @@ model = OperationalModel(
     Dict(CO2 => FixedProfile(100)),
     CO2,
 )
-case = Dict(:T => 𝒯, :nodes => nodes, :links => links, :products => resources)
+case = Case(𝒯, 𝒫, [𝒩, ℒ])
 m = EMB.run_model(case, model, OPTIMIZER)
 
 # Testing the correct source usage

--- a/test/network/test_LimitedFlexibleInput.jl
+++ b/test/network/test_LimitedFlexibleInput.jl
@@ -3,6 +3,7 @@ NG = ResourceCarrier("NG", 0.2)
 H2 = ResourceCarrier("H2", 0.0)
 gas_LHV = ResourceCarrier("gas LHV", 0)
 CO2 = ResourceEmit("CO2", 1.0)
+𝒫 = [NG, H2, gas_LHV, CO2]
 
 source_1 = RefSource(
     1,
@@ -39,12 +40,11 @@ sink = RefSink(
 )
 
 # Creating and solving the model
-resources = [NG, H2, gas_LHV, CO2]
 𝒯 = TwoLevel(2, 2, SimpleTimes(5, 2))
 𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-nodes = [source_1, source_2, combustion, sink]
-links = [
+𝒩 = [source_1, source_2, combustion, sink]
+ℒ = [
     Direct(13, source_1, combustion),
     Direct(23, source_2, combustion),
     Direct(34, combustion, sink),
@@ -54,7 +54,7 @@ model = OperationalModel(
     Dict(CO2 => FixedProfile(100)),
     CO2,
 )
-case = Dict(:T => 𝒯, :nodes => nodes, :links => links, :products => resources)
+case = Case(𝒯, 𝒫, [𝒩, ℒ])
 m = EMB.run_model(case, model, OPTIMIZER)
 
 # Testing the correct source usage

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,8 @@ function run_node_test(node_supertype::String, node_type::String)
     end
 end
 
+include("utils.jl")
+
 @testset "Flex" begin
     # Run all Aqua tests
     include("Aqua.jl")

--- a/test/sink/test_BinaryMultipleInputSinkStrat.jl
+++ b/test/sink/test_BinaryMultipleInputSinkStrat.jl
@@ -3,6 +3,7 @@ NG = ResourceCarrier("NG", 0.2)
 H2 = ResourceCarrier("H2", 0.0)
 power = ResourceCarrier("Power", 0.0)
 CO2 = ResourceEmit("CO2", 1.0)
+𝒫 = [NG, H2, CO2, power]
 
 source_1 = RefSource(
     1,
@@ -40,7 +41,6 @@ sink_2 = BinaryMultipleInputSinkStrat(
 )
 
 # Creating and solving the model
-𝒫 = [NG, H2, CO2, power]
 𝒯 = TwoLevel(2, 2, SimpleTimes(5, 2))
 𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
@@ -54,7 +54,7 @@ model = OperationalModel(
     Dict(CO2 => FixedProfile(100)),
     CO2,
 )
-case = Dict(:T => 𝒯, :nodes => 𝒩, :links => ℒ, :products => 𝒫)
+case = Case(𝒯, 𝒫, [𝒩, ℒ])
 m = EMB.run_model(case, model, OPTIMIZER)
 
 # Test the correct variable definition and that the variable is a sparse axis array

--- a/test/sink/test_ContinuousMultipleInputSinkStrat.jl
+++ b/test/sink/test_ContinuousMultipleInputSinkStrat.jl
@@ -77,7 +77,7 @@ end
 for t_inv ∈ 𝒯ᴵⁿᵛ
     if t_inv.sp == 1
         @test all(value.(m[:flow_out][source_1, t, NG]) ≈ 10 for t ∈ t_inv)
-        @test all(value.(m[:flow_out][source_2, t, H2]) ≈ 2.9333333 for t ∈ t_inv)
+        @test all(value.(m[:flow_out][source_2, t, H2]) ≈ 2.933333333 for t ∈ t_inv)
     else
         @test all(value.(m[:flow_out][source_1, t, NG]) ≈ 5 for t ∈ t_inv)
         @test all(value.(m[:flow_out][source_2, t, H2]) ≈ 4 for t ∈ t_inv)

--- a/test/sink/test_LoadShiftingNode.jl
+++ b/test/sink/test_LoadShiftingNode.jl
@@ -101,6 +101,7 @@ desired_cap_use = OperationalProfile([
 
 CO2 = ResourceEmit("CO2", 1.0)
 Power = ResourceCarrier("Power", 0.0)
+products = [Power, CO2]
 
 power_source = RefSource(
     1,
@@ -122,10 +123,9 @@ load_shift_demand = LoadShiftingNode(
     3, # load_shift_times_per_period
 )
 
-links = [Direct(12, power_source, load_shift_demand)]
-nodes = [power_source, load_shift_demand]
-products = [Power, CO2]
-case = Dict(:T => 𝒯, :nodes => nodes, :products => products, :links => links)
+ℒ = [Direct(12, power_source, load_shift_demand)]
+𝒩 = [power_source, load_shift_demand]
+case = Case(𝒯, 𝒫, [𝒩, ℒ])
 model = OperationalModel(
     Dict(CO2 => FixedProfile(100)),
     Dict(CO2 => FixedProfile(100)),

--- a/test/sink/test_MultipleInputSink.jl
+++ b/test/sink/test_MultipleInputSink.jl
@@ -2,6 +2,7 @@
 NG = ResourceCarrier("NG", 0.2)
 H2 = ResourceCarrier("H2", 0.0)
 CO2 = ResourceEmit("CO2", 1.0)
+𝒫 = [NG, H2, CO2]
 
 source_1 = RefSource(
     1,
@@ -26,18 +27,17 @@ sink = MultipleInputSink(
 )
 
 # Creating and solving the model
-resources = [NG, H2, CO2]
 𝒯 = TwoLevel(2, 2, SimpleTimes(5, 2))
 𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-nodes = [source_1, source_2, sink]
-links = [Direct(13, source_1, sink), Direct(23, source_2, sink)]
+𝒩 = [source_1, source_2, sink]
+ℒ = [Direct(13, source_1, sink), Direct(23, source_2, sink)]
 model = OperationalModel(
     Dict(CO2 => FixedProfile(100)),
     Dict(CO2 => FixedProfile(100)),
     CO2,
 )
-case = Dict(:T => 𝒯, :nodes => nodes, :links => links, :products => resources)
+case = Case(𝒯, 𝒫, [𝒩, ℒ])
 m = EMB.run_model(case, model, OPTIMIZER)
 
 # Testing the correct source usage

--- a/test/source/test_PayAsProducedPPA.jl
+++ b/test/source/test_PayAsProducedPPA.jl
@@ -1,6 +1,7 @@
 
 Power = ResourceCarrier("Power", 0.0)
 CO2 = ResourceEmit("CO2", 1.0)
+𝒫 = [Power, CO2]
 
 source_1 = PayAsProducedPPA(
     1,
@@ -25,12 +26,11 @@ sink = RefSink(
 )
 
 # Creating and solving the model
-resources = [Power, CO2]
 𝒯 = TwoLevel(2, 2, SimpleTimes(5, 2))
 𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-nodes = [source_1, source_2, sink]
-links = [
+𝒩 = [source_1, source_2, sink]
+ℒ = [
     Direct(13, source_1, sink),
     Direct(23, source_2, sink),
 ]
@@ -39,7 +39,7 @@ model = OperationalModel(
     Dict(CO2 => FixedProfile(100)),
     CO2,
 )
-case = Dict(:T => 𝒯, :nodes => nodes, :links => links, :products => resources)
+case = Case(𝒯, 𝒫, [𝒩, ℒ])
 m = EMB.run_model(case, model, OPTIMIZER)
 
 # We only have curtailment in the first strategic period

--- a/test/storage/test_StorageEfficiency.jl
+++ b/test/storage/test_StorageEfficiency.jl
@@ -1,6 +1,7 @@
 
 Power = ResourceCarrier("Power", 0.0)
 CO2 = ResourceEmit("CO2", 1.0)
+𝒫 = [Power, CO2]
 
 source_1 = RefSource(
     1,
@@ -38,12 +39,11 @@ sink = RefSink(
 )
 
 # Creating and solving the model
-resources = [Power, CO2]
 𝒯 = TwoLevel(2, 2, SimpleTimes(5, 1))
 𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-nodes = [source_1, av, battery, sink]
-links = [
+𝒩 = [source_1, av, battery, sink]
+ℒ = [
     Direct(12, source_1, av),
     Direct(23, av, battery),
     Direct(32, battery, av),
@@ -54,7 +54,7 @@ model = OperationalModel(
     Dict(CO2 => FixedProfile(100)),
     CO2,
 )
-case = Dict(:T => 𝒯, :nodes => nodes, :links => links, :products => resources)
+case = Case(𝒯, 𝒫, [𝒩, ℒ])
 m = EMB.run_model(case, model, OPTIMIZER)
 
 # Testing the deficit


### PR DESCRIPTION
This PR increases the dependency version number due to the new version to [v0.9.0 EnergyModelsBase](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.0)

The adjustments required minor changes in the design of the individual tests and examples. It did not require any changes to the code itself.