### PR TITLE
Improvement to `CapacityCostLink`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Version 0.2.11 (2026-02-16)
+
+### Enhancements
+
+* Extended the link `CapacityCostLink` to also accept a vector of durations for the individual sub periods.
+
 ## Version 0.2.10 (2026-01-05)
 
 ### Enhancements

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsFlex"
 uuid = "a81b9388-333d-4b63-81f2-910b060b544c"
 authors = ["Sigrid Aunsmo, Sigmund Eggen Holm, Jon Vegard Venås, and Per Åslid"]
-version = "0.2.10"
+version = "0.2.11"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"

--- a/docs/src/library/internals/methods-EMF.md
+++ b/docs/src/library/internals/methods-EMF.md
@@ -9,14 +9,16 @@ Pages = ["methods-EMF.md"]
 ## [Check methods](@id lib-int-met-check)
 
 ```@docs
-EnergyModelsFlex.check_period_ts
-EnergyModelsFlex.check_limits_default
-EnergyModelsFlex.check_input
+EMF.check_period_ts
+EMF.check_limits_default
+EMF.check_input
+EMF.check_cap_price_periods
 ```
 
 ## [Utility functions](@id lib-int-links-fun_utils)
 
 ```@docs
-EnergyModelsFlex.avg_cap_price
-EnergyModelsFlex.create_sub_periods
+EMF.get_avg_cap_price
+EMF.get_sub_periods
+EMF.get_sub_pers_durations
 ```

--- a/docs/src/links/capacitycostlink.md
+++ b/docs/src/links/capacitycostlink.md
@@ -44,10 +44,17 @@ The following additional fields are included for [`CapacityCostLink`](@ref) link
   The price per unit of maximum capacity usage over the sub-periods.
   This value is averaged over sub-periods as defined by `cap_price_periods`.
   All values have to be non-negative.
-- **`cap_price_periods::Int64`** :\
-  The number of sub-periods within a year for which the capacity cost is calculated.
+  !!! danger "Price values"
+      The provided value for the field `cap_price` is an absolute value in a strategic period and only related to the value of a strategic period duration of 1.
+      In the case of a strategic period duration of 1 corresponding to 1 year and a capacity of 1 GW, you must provide the value in €/GW/year, even if the capacity is only used for 1 month.
+      It is hence independent of the chosen number of sub periods or the durations of the sub periods.
+
+      It is planned to change this behavior in the future.
+      The change corresponds to a breaking change as we change the behavior of the model.
+- **`cap_price_periods::Union{Int64, Vector{<:Number}}`** :\
+  The number of sub-periods within a year for which the capacity cost is calculated (if specifying an `Int64`) or the duration of the individual sub periods (if specifying a `Vector{<:Number}`).
   This allows modeling of varying peak demands across seasons.
-  The value must be positive.
+  The value must be positive if your are using an `Int64` (and hence specifiy the number of periods) or all values of be positive and summing up to the specified scaling factor between operational and strategic period durations (the parameter `op_per_strat`) if you are using a `Vector{<:Number}`.
 
   !!! tip "Number of sub-periods"
       For investment periods with many operational periods, consider increasing the number of `cap_price_periods`.
@@ -126,7 +133,11 @@ The capacity cost is calculated as:
 \texttt{ccl\_cap\_use\_cost}[l, t_{sub}] = \texttt{ccl\_cap\_use\_max}[l, t_{sub}] \times \overline{cap\_price}(l, t_{sub})
 ```
 
-where ``\overline{cap\_price}`` is the average capacity price over the sub-period.
+where ``\overline{cap\_price}`` is the average capacity price over the sub-period calculated as:
+
+```math
+\overline{cap\_price}(l, t_{sub}) = \frac{\sum_{t \in t_{sub}} cap\_price(l, t) \times duration(t)}{\sum_{t \in t_{sub}} duration(t)}
+```
 
 Finally, costs are aggregated to each strategic period:
 
@@ -134,7 +145,7 @@ Finally, costs are aggregated to each strategic period:
 \texttt{link\_opex\_var}[l, t_{inv}] = \sum_{t_{sub} \in t_{inv}} \texttt{ccl\_cap\_use\_cost}[l, t_{sub}]
 ```
 
-In addition, the energy flow of the constrained resource should not exceed the maximum pipe capacity, which is included through the following constraint:
+In addition, the energy flow of the constrained resource should not exceed the maximum capacity, which is included through the following constraint:
 
 ```math
 \texttt{flow\_in}[l, t, cap\_resource(l)] \leq \texttt{link\_cap\_inst}[l, t]

--- a/docs/src/links/capacitycostlink.md
+++ b/docs/src/links/capacitycostlink.md
@@ -45,9 +45,14 @@ The following additional fields are included for [`CapacityCostLink`](@ref) link
   This value is averaged over sub-periods as defined by `cap_price_periods`.
   All values have to be non-negative.
   !!! danger "Price values"
-      The provided value for the field `cap_price` is an absolute value in a strategic period and only related to the value of a strategic period duration of 1.
-      In the case of a strategic period duration of 1 corresponding to 1 year and a capacity of 1 GW, you must provide the value in €/GW/year, even if the capacity is only used for 1 month.
-      It is hence independent of the chosen number of sub periods or the durations of the sub periods.
+
+      The value given in `cap_price` is interpreted on the strategic-period scale (*e.g.*, if a strategic-period duration of `1` corresponds to 1 year, then the natural unit is €/GW/year).
+      Capacity costs are calculated per sub-period and then summed over the strategic period.
+      This means a constant value (*e.g.,* €/GW/year) is effectively applied once for each sub-period (based on the peak within that sub-period), and is not automatically scaled by sub-period duration.
+
+      Example: With `cap_price = 100 €/GW/year`, `cap_price_periods = 12`, and a peak usage of 1 GW in each month, the model computes a total cost of 12 × 100 = 1200 €/year.
+
+      To achieve seasonal/monthly peak charges, define multiple `cap_price_periods` and provide `cap_price` values that represent the intended charge per sub-period (or scale the values accordingly).
 
       It is planned to change this behavior in the future.
       The change corresponds to a breaking change as we change the behavior of the model.

--- a/src/link/checks.jl
+++ b/src/link/checks.jl
@@ -4,9 +4,11 @@
 This method checks that the *[`CapacityCostLink`](@ref)* link is valid.
 
 ## Checks
- - The field `cap` is required to be non-negative.
- - The field `cap_price` is required to be non-negative.
- - The field `cap_price_period` is required to be positive.
+- The field `cap` is required to be non-negative.
+- The field `cap_price` is required to be non-negative.
+- The field `check_cap_price_periods` must follow the rules oulined in the subfunction
+  [`check_cap_price_periods`](@ref), that is it must either be a positive number or the
+  durations must sum up to the value `op_per_strat` of the time structure.
 """
 function EMB.check_link(l::CapacityCostLink, 𝒯, ::EnergyModel, ::Bool)
     @assert_or_log(
@@ -17,14 +19,46 @@ function EMB.check_link(l::CapacityCostLink, 𝒯, ::EnergyModel, ::Bool)
         all(cap_price(l)[t] ≥ 0 for t ∈ 𝒯),
         "The capacity price must be non-negative."
     )
+    check_cap_price_periods(l, 𝒯, cap_price_periods(l))
+end
+
+"""
+    check_cap_price_periods(l::CapacityCostLink, 𝒯, price_pers::Int64)
+    check_cap_price_periods(l::CapacityCostLink, 𝒯, price_pers::Vector{<:Number})
+
+This method checks that the field `check_cap_price_periods` is correct.
+
+## Checks
+- If the field is an `Int64`, the field `check_cap_price_periods` is required to be positive.
+- If the field is an `Vector{<:Number}`, the field `check_cap_price_periods` is required to sum
+  up to the value `op_per_strat` and each value in the `Vector` must be positive.
+- The individual capacity price periods must be able to represent the operational time
+  structure
+"""
+function check_cap_price_periods(l::CapacityCostLink, 𝒯, price_pers::Int64)
     @assert_or_log(
-        cap_price_periods(l) > 0,
-        "The the number of sub periods of a year must be positive."
+        price_pers > 0,
+        "The number of sub periods of a strategic period must be positive."
     )
-    sub_periods = create_sub_periods(l, 𝒯)
-    @assert_or_log(
-        vcat(sub_periods...) == collect(𝒯),
+    price_pers > 0 && @assert_or_log(
+        vcat(get_sub_periods(l, 𝒯)...) == collect(𝒯),
         "The operational period durations could not accumulate into `cap_price_periods =
-        $(cap_price_periods(l))` sub periods of each strategic period."
+        $(price_pers)` sub periods of each strategic period."
+    )
+end
+function check_cap_price_periods(l::CapacityCostLink, 𝒯, price_pers::Vector{<:Number})
+    @assert_or_log(
+        sum(price_pers) ≈ 𝒯.op_per_strat,
+        "The duration of all sub periods must be equal to the value `op_per_strat` of the " *
+        "time structure."
+    )
+    @assert_or_log(
+        all(price_pers .> 0),
+        "Each sub period must have a positive duration."
+    )
+    @assert_or_log(
+        vcat(get_sub_periods(l, 𝒯)...) == collect(𝒯),
+        "The operational period durations could not accumulate into `cap_price_periods =
+        $(length(price_pers))` sub periods of each strategic period."
     )
 end

--- a/src/link/datastructures.jl
+++ b/src/link/datastructures.jl
@@ -1,5 +1,5 @@
 """
-    CapacityCostLink
+    struct CapacityCostLink <: Link
 
 A link between two nodes with costs on the link usage for the resource `cap_resource`. All
 other resources have no costs associated with their usage (follows the
@@ -11,12 +11,20 @@ other resources have no costs associated with their usage (follows the
 - **`to::Node`** is the node to which there is flow out of the link.
 - **`cap::TimeProfile`** is the capacity of the link for the `cap_resource`.
 - **`cap_price::TimeProfile`** is the price of capacity usage for the `cap_resource`.
-- **`cap_price_periods::Int64`** is the number of sub periods of a year.
+- **`cap_price_periods::Union{Int64, Vector{<:Number}}`** is either the number of sub periods
+  within a strategic period (if specified as `Int64`) or the minimum durations of the
+  individual sub periods within a strategic period (if specified as `Vector{<:Number}`).
 - **`cap_resource::Resource`** is the resource used by `CapacityCostLink`
-- **`formulation::Formulation`** is the used formulation of links. The field
-  `formulation` is conditional through usage of a constructor.
+- **`formulation::Formulation`** is the used formulation of links. The field `formulation`
+  is conditional through usage of a constructor.
 - **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments). The
   field `data` is conditional through usage of a constructor.
+
+!!! note "Sub periods"
+    You can specify either the total number of sub periods within a `CapacityCostLink` as
+    `Int64` or the durations of each sub period if using a `Vector{<:Number}`. The latter
+    requires you to be careful when considering the durations of the individual sub periods
+    and the total duration of sub periods within the operational time structure.
 """
 struct CapacityCostLink <: EMB.Link
     id::Any
@@ -24,7 +32,7 @@ struct CapacityCostLink <: EMB.Link
     to::EMB.Node
     cap::TimeProfile
     cap_price::TimeProfile
-    cap_price_periods::Int64
+    cap_price_periods::Union{Int64, Vector{<:Number}}
     cap_resource::Resource
     formulation::EMB.Formulation
     data::Vector{<:ExtensionData}
@@ -36,7 +44,7 @@ function CapacityCostLink(
     to::EMB.Node,
     cap::TimeProfile,
     cap_price::TimeProfile,
-    cap_price_periods::Int64,
+    cap_price_periods::Union{Int64, Vector{<:Number}},
     cap_resource::Resource,
     formulation::EMB.Formulation,
 )
@@ -58,7 +66,7 @@ function CapacityCostLink(
     to::EMB.Node,
     cap::TimeProfile,
     cap_price::TimeProfile,
-    cap_price_periods::Int64,
+    cap_price_periods::Union{Int64, Vector{<:Number}},
     cap_resource::Resource,
     data::Vector{<:ExtensionData},
 )
@@ -80,7 +88,7 @@ function CapacityCostLink(
     to::EMB.Node,
     cap::TimeProfile,
     cap_price::TimeProfile,
-    cap_price_periods::Int64,
+    cap_price_periods::Union{Int64, Vector{<:Number}},
     cap_resource::Resource,
 )
     return CapacityCostLink(
@@ -147,8 +155,8 @@ cap_price(l::CapacityCostLink, t) = l.cap_price[t]
 """
     cap_price_periods(l::CapacityCostLink)
 
-Returns the number of sub-periods within a year for which a price is calculated of a capacity
-cost link `l`.
+Returns either the number of sub-periods within a strategic period for which a price is
+calculated or the vector of the durations of the sub-periods of a capacity cost link `l`.
 """
 cap_price_periods(l::CapacityCostLink) = l.cap_price_periods
 

--- a/src/link/model.jl
+++ b/src/link/model.jl
@@ -8,8 +8,8 @@ Creates the following additional variable for **ALL** capacity cost links:
   for a [`CapacityCostLink`](@ref) `l` in operational period `t`.
 """
 function EMB.variables_element(m, ℒˢᵘᵇ::Vector{<:CapacityCostLink}, 𝒯, ::EnergyModel)
-    @variable(m, ccl_cap_use_max[ℒˢᵘᵇ, 𝒯] >= 0)
-    @variable(m, ccl_cap_use_cost[ℒˢᵘᵇ, 𝒯] >= 0)
+    @variable(m, ccl_cap_use_max[ℒˢᵘᵇ, 𝒯] ≥ 0)
+    @variable(m, ccl_cap_use_cost[ℒˢᵘᵇ, 𝒯] ≥ 0)
 end
 
 """
@@ -33,7 +33,7 @@ function EMB.create_link(
     p_cap = cap_resource(l)
 
     # Create sub-periods based on the user-defined number of sub periods of a year
-    𝒯ˢᵘᵇ = create_sub_periods(l, 𝒯)
+    𝒯ˢᵘᵇ = get_sub_periods(l, 𝒯)
 
     # Capacity cost link where output equals input (no losses)
     @constraint(m, [t ∈ 𝒯],
@@ -52,7 +52,7 @@ function EMB.create_link(
     # Capacity cost constraint
     @constraint(m, [t_sub ∈ 𝒯ˢᵘᵇ],
         m[:ccl_cap_use_cost][l, t_sub[end]] ==
-        m[:ccl_cap_use_max][l, t_sub[end]] * avg_cap_price(l, t_sub)
+        m[:ccl_cap_use_max][l, t_sub[end]] * get_avg_cap_price(l, t_sub)
     )
 
     # Sum up costs for each sub_period into the strategic period cost
@@ -68,28 +68,28 @@ function EMB.create_link(
 end
 
 """
-    avg_cap_price(l::CapacityCostLink, t_sub::Vector{TS.TimePeriod})
+    get_avg_cap_price(l::CapacityCostLink, t_sub::Vector{TS.TimePeriod})
 
 Return the average capacity price over the sub period `t_sub` for the [`CapacityCostLink`](@ref) `l`.
 """
-function avg_cap_price(l::CapacityCostLink, t_sub::Vector{<:TS.TimePeriod})
+function get_avg_cap_price(l::CapacityCostLink, t_sub::Vector{<:TS.TimePeriod})
     return sum(cap_price(l, t) * duration(t) for t ∈ t_sub) / sum(duration(t) for t ∈ t_sub)
 end
 
 """
-    create_sub_periods(l::CapacityCostLink, 𝒯)
+    get_sub_periods(l::CapacityCostLink, 𝒯)
 
-Extract sub periods of the [`CapacityCostLink`](@ref) `l`.
+Return the vector of sub periods of the [`CapacityCostLink`](@ref) `l`.
 """
-function create_sub_periods(l::CapacityCostLink, 𝒯)
-    # Calculate the length of each sub period
-    sub_period_duration::Float64 = 𝒯.op_per_strat / cap_price_periods(l)
+function get_sub_periods(l::CapacityCostLink, 𝒯)
+    # Calculate the duration of each sub period
+    sub_pers_durations = get_sub_pers_durations(l, 𝒯)
 
-    # Create a vector collecting all `TimePeriod`s of each sub period into a vector for each
-    # sub period
+    # Create a vector collecting all `TimePeriod`s of each sub period into a vector
     sub_periods = Vector{TS.TimePeriod}[]
     for t_inv ∈ strategic_periods(𝒯)
-        accumulated_duration::Float64 = 0.0
+    idx = 1
+        accumulated_duration = 0.0
         sub_period = TS.TimePeriod[]
         for t ∈ t_inv
             push!(sub_period, t)
@@ -97,13 +97,28 @@ function create_sub_periods(l::CapacityCostLink, 𝒯)
 
             # Check if the accumulated time of the periods in `sub_period` fills up a sub
             # period duration
-            if accumulated_duration ≈ sub_period_duration
+            if accumulated_duration ≈ sub_pers_durations[idx]
                 push!(sub_periods, sub_period)
                 sub_period = TS.TimePeriod[]
-                accumulated_duration = 0
+                accumulated_duration = 0.0
+                idx += 1
             end
         end
     end
 
     return sub_periods
 end
+
+"""
+    get_sub_pers_durations(l::CapacityCostLink, 𝒯)
+    get_sub_pers_durations(l::CapacityCostLink, 𝒯, price_pers::Int64)
+    get_sub_pers_durations(l::CapacityCostLink, 𝒯, price_pers::Vector{<:Number})
+
+Returns the individual durations of the different sub periods within a time structure `𝒯`
+and [`CapacityCostLink`](@ref) `l`.
+"""
+get_sub_pers_durations(l::CapacityCostLink, 𝒯) =
+    get_sub_pers_durations(l, 𝒯, cap_price_periods(l))
+get_sub_pers_durations(l::CapacityCostLink, 𝒯, price_pers::Int64) =
+    ones(price_pers) * 𝒯.op_per_strat / price_pers
+get_sub_pers_durations(l::CapacityCostLink, 𝒯, price_pers::Vector{<:Number}) = price_pers

--- a/test/link/test_CapacityCostLink.jl
+++ b/test/link/test_CapacityCostLink.jl
@@ -5,14 +5,14 @@ co2 = ResourceEmit("CO₂", 0.0)
 function capacity_cost_link_case(;
     cap = FixedProfile(10),
     capacity_price = StrategicProfile([5e5, 1e6, 2e6]),
-    capacity_price_period = 2,
+    capacity_price_periods = 2,
 )
     # Define the different resources
     𝒫 = [power, co2]
 
     # Creation of the time structure
     op_number = 24
-    𝒯 = TwoLevel([1, 2, 10], SimpleTimes(op_number, 1); op_per_strat = 8760)
+    𝒯 = TwoLevel([1, 2, 10], SimpleTimes(op_number, 2); op_per_strat = 8760)
 
     # Create the nodes
     𝒩 = [
@@ -47,7 +47,7 @@ function capacity_cost_link_case(;
             𝒩[3],
             cap,
             capacity_price,
-            capacity_price_period,
+            capacity_price_periods,
             power,
         ),
     ]
@@ -78,12 +78,21 @@ end
     @test_throws AssertionError capacity_cost_link_case(; capacity_price)
 
     # Test that the number of sub periods is positive
-    @test_throws AssertionError capacity_cost_link_case(capacity_price_period = 0)
-    @test_throws AssertionError capacity_cost_link_case(capacity_price_period = -1)
+    @test_throws AssertionError capacity_cost_link_case(; capacity_price_periods = 0)
+    @test_throws AssertionError capacity_cost_link_case(; capacity_price_periods = -1)
 
-    # Test that operational periods can accumulate into cap_price_periods sub periods
-    # (8760 is not divisible by 7 sub periods)
-    @test_throws AssertionError capacity_cost_link_case(capacity_price_period = 7)
+    # Test that operational time structure can can be represented by `cap_price_periods`
+    # sub periods when specified as `Int64` (8760 is not divisible by 7 sub periods)
+    @test_throws AssertionError capacity_cost_link_case(; capacity_price_periods = 7)
+
+    # Test that the sum of sub periods is equal to the operational time structure duration
+    capacity_price_periods = ones(24)
+    @test_throws AssertionError capacity_cost_link_case(; capacity_price_periods)
+
+    # Test that that none of the durations of the sub periods is not positive
+    capacity_price_periods =
+        [0.0, 4.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0] * 365
+    @test_throws AssertionError capacity_cost_link_case(; capacity_price_periods)
 
     # Set the global to true to suppress the error message
     EMB.TEST_ENV = false
@@ -94,6 +103,7 @@ end
     m, case, modeltype = capacity_cost_link_case()
     cc_link = get_links(case)[2]
     𝒯 = get_time_struct(case)
+    sub_periods = EMF.get_sub_periods(cc_link, 𝒯)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     @testset "EMX functions" begin
@@ -115,6 +125,34 @@ end
         @test EMF.cap_price(cc_link).vals == capacity_prices.vals
         @test EMF.cap_price_periods(cc_link) == 2
         @test EMF.cap_resource(cc_link) == power
+
+        @test EMF.get_sub_pers_durations(cc_link, 𝒯) == [4380.0, 4380.0]
+        @test all(sub_periods[k] ==
+            collect(𝒯)[1+12*(k-1):12*k] for k ∈ 1:6)
+        @test all(EMF.get_avg_cap_price(cc_link, sub_periods[k]) ≈ 5e5 for k ∈ 1:2)
+        @test all(EMF.get_avg_cap_price(cc_link, sub_periods[k]) ≈ 1e6 for k ∈ 3:4)
+        @test all(EMF.get_avg_cap_price(cc_link, sub_periods[k]) ≈ 2e6 for k ∈ 5:6)
+
+        # Test that the new functions are also working based on specified durations
+        capacity_price_periods = [3650.0, 5110.0]
+        capacity_price = StrategicProfile([
+            OperationalProfile(vcat(ones(12) * 5e5, ones(12) * 2e5)),
+            OperationalProfile(vcat(ones(12) * 1e6, ones(12) * 5e5)),
+            OperationalProfile(vcat(ones(12) * 2e6, ones(12) * 1e6)),
+        ])
+
+        m, case, modeltype = capacity_cost_link_case(; capacity_price_periods, capacity_price)
+        cc_link = get_links(case)[2]
+        𝒯 = get_time_struct(case)
+        sub_periods = EMF.get_sub_periods(cc_link, 𝒯)
+
+        @test EMF.get_sub_pers_durations(cc_link, 𝒯) == capacity_price_periods
+        @test all(sub_periods[1+2*(k-1)] ==
+            collect(𝒯)[1+24*(k-1):10*k+14*(k-1)] for k ∈ 1:3)
+        @test all(sub_periods[2*k] ==
+            collect(𝒯)[11+24*(k-1):24*k] for k ∈ 1:3)
+        @test EMF.get_avg_cap_price(cc_link, sub_periods[1]) ≈ 5e5
+        @test EMF.get_avg_cap_price(cc_link, sub_periods[2]) ≈ (5e5*2 + 2e5*12)/14
     end
 end
 
@@ -174,7 +212,55 @@ end
 end
 
 @testset "Constraint implementation" begin
-    # Create the case and modeltype
+
+    function ccl_standard_test(cc_link::CapacityCostLink, 𝒯)
+        # No losses: link_out == link_in
+        @test all(
+            value(m[:link_out][cc_link, t, p]) ≈ value(m[:link_in][cc_link, t, p])
+            for t ∈ 𝒯, p ∈ inputs(cc_link)
+        )
+
+        # Capacity constraint: link_in ≤ link_cap_inst
+        @test all(
+            value(m[:link_in][cc_link, t, power]) ≲ value(m[:link_cap_inst][cc_link, t])
+            for t ∈ 𝒯
+        )
+        @test all(
+            value(m[:link_cap_inst][cc_link, t]) ≈ capacity(cc_link, t)
+            for t ∈ 𝒯
+        )
+
+        # Max capacity use per sub-period:
+        #    link_in[t] ≤ ccl_cap_use_max[t_sub_end]
+        @test all(
+            all(
+                value(m[:link_in][cc_link, t, power]) ≲
+                value(m[:ccl_cap_use_max][cc_link, t_sub[end]])
+                for t ∈ t_sub
+            )
+            for t_sub ∈ 𝒯ˢᵘᵇ
+        )
+
+        # Capacity cost at end of sub-period: cap_cost == max_cap_use * get_avg_cap_price
+        @test all(
+            value(m[:ccl_cap_use_cost][cc_link, t_sub[end]]) ≈
+            value(m[:ccl_cap_use_max][cc_link, t_sub[end]]) * EMF.get_avg_cap_price(cc_link, t_sub)
+            for t_sub ∈ 𝒯ˢᵘᵇ
+        )
+
+        # Strategic-period sum: link_opex_var == sum(ccl_cap_use_cost over t_inv)
+        @test all(
+            value(m[:link_opex_var][cc_link, t_inv]) ≈
+                sum(value(m[:ccl_cap_use_cost][cc_link, t]) for t ∈ t_inv)
+            for t_inv ∈ 𝒯ᴵⁿᵛ
+        )
+
+        # Check that there is no sink deficit or surplus
+        @test all(value.(m[:sink_deficit][sink, t]) ≈ 0.0 for t ∈ 𝒯)
+        @test all(value.(m[:sink_surplus][sink, t]) ≈ 0.0 for t ∈ 𝒯)
+    end
+
+    # Create the case and modeltype when specifiying the number of periods
     m, case, modeltype = capacity_cost_link_case()
 
     # Optimize the model and conduct the general tests
@@ -185,70 +271,87 @@ end
     # Extract the individual elements
     src_cheap, src_exp, sink = get_nodes(case)
     direct_link, cc_link = get_links(case)
-
     𝒯 = get_time_struct(case)
-    𝒯ˢᵘᵇ = EMF.create_sub_periods(cc_link, 𝒯)
+    𝒯ˢᵘᵇ = EMF.get_sub_periods(cc_link, 𝒯)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-    # No losses: link_out == link_in
-    @test all(
-        value(m[:link_out][cc_link, t, p]) ≈ value(m[:link_in][cc_link, t, p])
-        for t ∈ 𝒯, p ∈ inputs(cc_link)
-    )
-
-    # Capacity constraint: link_in ≤ link_cap_inst
-    @test all(
-        value(m[:link_in][cc_link, t, power]) ≲ value(m[:link_cap_inst][cc_link, t])
-        for t ∈ 𝒯
-    )
-    @test all(
-        value(m[:link_cap_inst][cc_link, t]) ≈ capacity(cc_link, t)
-        for t ∈ 𝒯
-    )
-
-    # Max capacity use per sub-period:
-    #    link_in[t] ≤ ccl_cap_use_max[t_sub_end]
-    @test all(
-        all(
-            value(m[:link_in][cc_link, t, power]) ≲
-            value(m[:ccl_cap_use_max][cc_link, t_sub[end]])
-            for t ∈ t_sub
-        )
-        for t_sub ∈ 𝒯ˢᵘᵇ
-    )
-
-    # Capacity cost at end of sub-period: cap_cost == max_cap_use * avg_cap_price
-    @test all(
-        value(m[:ccl_cap_use_cost][cc_link, t_sub[end]]) ≈
-        value(m[:ccl_cap_use_max][cc_link, t_sub[end]]) * EMF.avg_cap_price(cc_link, t_sub)
-        for t_sub ∈ 𝒯ˢᵘᵇ
-    )
-
-    # Strategic-period sum: link_opex_var == sum(ccl_cap_use_cost over t_inv)
-    @test all(
-        value(m[:link_opex_var][cc_link, t_inv]) ≈
-            sum(value(m[:ccl_cap_use_cost][cc_link, t]) for t ∈ t_inv)
-        for t_inv ∈ 𝒯ᴵⁿᵛ
-    )
-
-    # Check that there is no sink deficit or surplus
-    @test all(value.(m[:sink_deficit][sink, t]) ≈ 0.0 for t ∈ 𝒯)
-    @test all(value.(m[:sink_surplus][sink, t]) ≈ 0.0 for t ∈ 𝒯)
+    # Perform the standard tests
+    ccl_standard_test(cc_link, 𝒯)
 
     # Check that the `CapacityCostLink` is only used up to a capacity of 1.0 to limit
     # the opex on the line (the remaining demand is covered by the `Direct` link)
     @test all(value.(m[:link_out][direct_link, t, power]) ≈ 0.0 for t ∈ 𝒯ˢᵘᵇ[2])
     @test all(value.(m[:link_out][cc_link, t, power]) ≈ 1.0 for t ∈ 𝒯ˢᵘᵇ[1])
 
-    # Check that the opex is correct
-    @test value.(m[:link_opex_var][cc_link, 𝒯ᴵⁿᵛ[1]]) ≈ 2 * 5e5 * 1.0 # A capacity of 1.0 is used over both sub periods (having a opex of 5e5 each)
-    @test value.(m[:link_opex_var][cc_link, 𝒯ᴵⁿᵛ[2]]) ≈ 2 * 1e6 * 1.0 # A capacity of 1.0 is used over both sub periods (having a opex of 1e6 each)
-    @test value.(m[:link_opex_var][cc_link, 𝒯ᴵⁿᵛ[3]]) ≈ 0.0 # Due to a high capacity cost of 2e6, the link is not used
+    # Check that the opex of the CapacityCostLink is correct
+    # Sp1: A capacity of 1.0 is used over both sub periods (having an opex of 5e5 each)
+    # Sp2: A capacity of 1.0 is used over both sub periods (having an opex of 1e6 each)
+    # Sp3: A capacity of 1.0 is used over both sub periods (having an opex of 1e6 each)
+    exp_val = StrategicProfile(2 * [5e5, 1e6, 0])
+    @test all(value.(m[:link_opex_var][cc_link, t_inv]) ≈ exp_val[t_inv] for t_inv ∈ 𝒯ᴵⁿᵛ)
 
-    # For the first two operational periods with demand 10 and 9 respectively, the
-    # Direct link covers the remaining demand (with `1.0` being provided by `cc_link`), which
-    # with a cost of 400 EUR/MW and scaled with the operational period duration gives:
-    @test value.(m[:opex_var][src_exp, 𝒯ᴵⁿᵛ[1]]) ≈ ((10-1) + (9-1)) * 400 * (8760/24)
-    @test value.(m[:opex_var][src_exp, 𝒯ᴵⁿᵛ[2]]) ≈ ((10-1) + (9-1)) * 400 * (8760/24)
-    @test value.(m[:opex_var][src_exp, 𝒯ᴵⁿᵛ[3]]) ≈ (10 + 9 + (24-2)*1) * 400 * (8760/24)
+    # Check that the opex of the expensive source is correct
+    # Sp1 and sp2: Only used to account for the peak additional demand (10-1 and 9-1)
+    # Sp3: Cover all demand
+    exp_val = StrategicProfile([
+        ((10-1) + (9-1)) * 400 * (8760/24),
+        ((10-1) + (9-1)) * 400 * (8760/24),
+        (10 + 9 + (24-2) * 1) * 400 * (8760/24),
+    ])
+    @test all(value.(m[:opex_var][src_exp, t_inv]) ≈ exp_val[t_inv] for t_inv ∈ 𝒯ᴵⁿᵛ)
+
+    # Create the case and modeltype when specifiying the duration of the periods
+    capacity_price_periods = [3650.0, 5110.0]
+    capacity_price = StrategicProfile([
+        OperationalProfile(vcat(ones(12) * 1e5, ones(12) * 2e5)),
+        OperationalProfile(vcat(ones(12) * 1e6, ones(12) * 5e5)),
+        OperationalProfile(vcat(ones(12) * 2e6, ones(12) * 1e6)),
+    ])
+
+    m, case, modeltype = capacity_cost_link_case(; capacity_price_periods, capacity_price)
+
+    # Optimize the model and conduct the general tests
+    set_optimizer(m, OPTIMIZER)
+    optimize!(m)
+    general_tests(m)
+
+    # Extract the individual elements
+    src_cheap, src_exp, sink = get_nodes(case)
+    direct_link, cc_link = get_links(case)
+    𝒯 = get_time_struct(case)
+    𝒯ˢᵘᵇ = EMF.get_sub_periods(cc_link, 𝒯)
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+
+    # Perform the standard tests
+    ccl_standard_test(cc_link, 𝒯)
+
+    # Check that the `CapacityCostLink` is only used up to a capacity of 1.0 in sp3, sub
+    # periods 1 to limit the opex on the line (the remaining demand is covered by the `Direct` link)
+    # The direct link is not used in sp1 due to the reduced costs
+    @test all(value.(m[:link_out][direct_link, t, power]) ≈ 0.0 for k ∈ [1,2,4] for t ∈ 𝒯ˢᵘᵇ[k])
+    @test all(value.(m[:link_out][cc_link, t, power]) ≈ 1.0 for t ∈ 𝒯ˢᵘᵇ[3])
+
+    # Check that the opex of the expensive source is correct
+    # Sp1: A capacity of 9.0 is used in the first sub period (having an opex of 1e5) and A
+    #      a capacity of 1.0 in the second sub period (having an opex of (1e5*2 + 2e5*12)/14)
+    # Sp2: A capacity of 1.0 is used over both sub periods (having an opex of 1e6 and
+    #      (1e6*2 + 5e5*12)/14, respectively)
+    # Sp3: A capacity of 0.0 is used in the first sub periods and a capacity of 1 in the
+    #      second sub period (with a cost of (2e6*2 + 1e6*12)/14)
+    exp_val = StrategicProfile([
+        FixedProfile(10 * 1e5  + 1 * (1e5*2 + 2e5*12)/14),
+        FixedProfile(1 * 1e6  + 1 * (1e6*2 + 5e5*12)/14),
+        FixedProfile(0 * 2e6  + 1 * (2e6*2 + 1e6*12)/14),
+    ])
+    @test all(value.(m[:link_opex_var][cc_link, t_inv]) ≈ exp_val[t_inv] for t_inv ∈ 𝒯ᴵⁿᵛ)
+
+    # Check that the opex of the expensive source is correct
+    # Sp1 and sp2: Only used to account for the peak additional demand
+    # Sp3: Cover all demand in the first sub period, but not in the second sub period
+    exp_val = StrategicProfile([
+        FixedProfile(0),
+        FixedProfile(((10-1) + (9-1)) * 400 * (8760/24)),
+        FixedProfile((10 + 9 + (10-2) * 1) * 400 * (8760/24)),
+    ])
+    @test all(value.(m[:opex_var][src_exp, t_inv]) ≈ exp_val[t_inv] for t_inv ∈ 𝒯ᴵⁿᵛ)
 end


### PR DESCRIPTION
The current implementation of `CapacityCostLink` only allows for equal length sub periods. This implies that you cannot model a full year with 8760 operational periods and each sub period section corresponding to a month. This is adjusted in this PR to allow for the field `cap_price_periods` to correspond to either a number of sub periods (when specifying an `Int64`) or the durations of the sub periods given the total duration with a strategic period as specified through the parameter `op_per_strat` of your time structure (when specifying a `Vector{<:Number}`.

In addition, some of the internal functions where renamed.