### PR TITLE
Improvement of MinUpDownTimeNode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # Release notes
 
+## Unversioned
+
+### Enhancements
+
+* Improved `MinUpDownTimeNode`:
+  * Rewrote the function `constraints_capacity` based on core functionality.
+  * Updated the test set to identify all potential problems with the node.
+
+
 ## Version 0.2.11 (2026-02-16)
 
 ### Enhancements
@@ -17,7 +26,6 @@
 
 * Removed `ext/EMGUIExt/descriptive_names.yml` as this will now be provided directly in `EnergyModelsGUI`.
 * Removed `docs/src/example/flexible_demand.md` as the markdown versions of the example files are now generated automatically (and these are thus added to the `.gitignore`-file).
-
 
 ## Version 0.2.9 (2025-07-08)
 

--- a/docs/src/links/capacitycostlink.md
+++ b/docs/src/links/capacitycostlink.md
@@ -87,7 +87,7 @@ with square brackets, while functions are represented as
 
 ``func\_example(index_1, index_2)``
 
-with paranthesis.
+with parantheses.
 
 ### [Variables](@id links-CapacityCostLink-math-var)
 

--- a/docs/src/nodes/network/activationcostnode.md
+++ b/docs/src/nodes/network/activationcostnode.md
@@ -25,7 +25,7 @@ The standard fields are given as:
   If the node should contain investments through the application of [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/), it is important to note that you can only use `FixedProfile` or `StrategicProfile` for the capacity, but not `RepresentativeProfile` or `OperationalProfile`.
   In addition, all values have to be non-negative.
 - **`opex_var::TimeProfile`**:\
-  The variable operational expenses are based on the capacity utilization through the variable [`:cap_use`](@extref EnergyModelsBase man-opt_var-cap).
+  The variable operating expenses are based on the capacity utilization through the variable [`:cap_use`](@extref EnergyModelsBase man-opt_var-cap).
   Hence, it is directly related to the specified `input` and `output` ratios.
   The variable operating expenses can be provided as `OperationalProfile` as well.
 - **`opex_fixed::TimeProfile`**:\

--- a/docs/src/nodes/network/combustion.md
+++ b/docs/src/nodes/network/combustion.md
@@ -22,7 +22,7 @@ The standard fields are given as:
   If the node should contain investments through the application of [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/), it is important to note that you can only use `FixedProfile` or `StrategicProfile` for the capacity, but not `RepresentativeProfile` or `OperationalProfile`.
   In addition, all values have to be non-negative.
 - **`opex_var::TimeProfile`**:\
-  The variable operational expenses are based on the capacity utilization through the variable [`:cap_use`](@extref EnergyModelsBase man-opt_var-cap).
+  The variable operating expenses are based on the capacity utilization through the variable [`:cap_use`](@extref EnergyModelsBase man-opt_var-cap).
   Hence, it is directly related to the specified `input` and `output` ratios.
   The variable operating expenses can be provided as `OperationalProfile` as well.
 - **`opex_fixed::TimeProfile`**:\

--- a/docs/src/nodes/network/flexibleoutput.md
+++ b/docs/src/nodes/network/flexibleoutput.md
@@ -21,7 +21,7 @@ The standard fields of a [`FlexibleOutput`](@ref) node are given as:
   If the node should contain investments through the application of [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/), it is important to note that you can only use `FixedProfile` or `StrategicProfile` for the capacity, but not `RepresentativeProfile` or `OperationalProfile`.
   In addition, all values have to be non-negative.
 - **`opex_var::TimeProfile`**:\
-  The variable operational expenses are based on the capacity utilization through the variable [`:cap_use`](@extref EnergyModelsBase man-opt_var-cap).
+  The variable operating expenses are based on the capacity utilization through the variable [`:cap_use`](@extref EnergyModelsBase man-opt_var-cap).
   Hence, it is directly related to the specified `input` and `output` ratios.
   The variable operating expenses can be provided as `OperationalProfile` as well.
 - **`opex_fixed::TimeProfile`**:\
@@ -66,7 +66,7 @@ with square brackets, while functions are represented as
 
 ``func\_example(index_1, index_2)``
 
-with paranthesis.
+with parantheses.
 
 ### [Variables](@id nodes-FlexibleOutput-math-var)
 

--- a/docs/src/nodes/network/limitedflexibleinput.md
+++ b/docs/src/nodes/network/limitedflexibleinput.md
@@ -18,7 +18,7 @@ The standard fields are given as:
   If the node should contain investments through the application of [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/), it is important to note that you can only use `FixedProfile` or `StrategicProfile` for the capacity, but not `RepresentativeProfile` or `OperationalProfile`.
   In addition, all values have to be non-negative.
 - **`opex_var::TimeProfile`**:\
-  The variable operational expenses are based on the capacity utilization through the variable [`:cap_use`](@extref EnergyModelsBase man-opt_var-cap).
+  The variable operating expenses are based on the capacity utilization through the variable [`:cap_use`](@extref EnergyModelsBase man-opt_var-cap).
   Hence, it is directly related to the specified `input` and `output` ratios.
   The variable operating expenses can be provided as `OperationalProfile` as well.
 - **`opex_fixed::TimeProfile`**:\

--- a/docs/src/nodes/network/minupdowntimenode.md
+++ b/docs/src/nodes/network/minupdowntimenode.md
@@ -55,18 +55,18 @@ The standard fields are given as:
 
 [`MinUpDownTimeNode`](@ref) nodes add four additional fields compared to a [`NetworkNode`](@extref EnergyModelsBase nodes-network_node):
 
-- **`minUpTime::Real`**:\
+- **`min_time_up::Real`**:\
   Minimum number of operational periods the unit must remain on after being started.
-- **`minDownTime::Real`**:\
+- **`min_time_down::Real`**:\
   Minimum number of operational periods the unit must remain off after being stopped.
-- **`minCapacity::Real`**:\
+- **`load_min::Real`**:\
   Minimum power output when the unit is on. The value must be larger than zero.
-- **`maxCapacity::Real`**:\
+- **`load_max::Real`**:\
   Maximum power output when the unit is on (usually aligned with `cap`).
-  The value must not be less than `minCapacity`.
+  The value must not be less than `load_min`.
 
 !!! tip
-    The fields `minUpTime` and `minDownTime` are defined in terms of operational period durations and should be consistent with the time granularity of the model.
+    The fields `min_time_up` and `min_time_down` are defined in terms of operational period durations and should be consistent with the time granularity of the model.
 
 ## [Mathematical description](@id nodes-minupdowntimenode-math)
 
@@ -194,11 +194,11 @@ The function `constraints_capacity` receives a new method to handle the minimum 
 - **Capacity conditional on on/off status:**
 
   ```math
-  \texttt{cap\_use}[n, t] \leq \texttt{on\_off}[n, t] \times n.maxCapacity
+  \texttt{cap\_use}[n, t] \leq \texttt{on\_off}[n, t] \times n.load_max
   ```
 
   ```math
-  \texttt{cap\_use}[n, t] \geq \texttt{on\_off}[n, t] \times n.minCapacity
+  \texttt{cap\_use}[n, t] \geq \texttt{on\_off}[n, t] \times n.load_min
   ```
 
 - **Upper bound by installed capacity:**

--- a/docs/src/nodes/network/minupdowntimenode.md
+++ b/docs/src/nodes/network/minupdowntimenode.md
@@ -21,7 +21,7 @@ The standard fields are given as:
   If the node should contain investments through the application of [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/), it is important to note that you can only use `FixedProfile` or `StrategicProfile` for the capacity, but not `RepresentativeProfile` or `OperationalProfile`.
   In addition, all values have to be non-negative.
 - **`opex_var::TimeProfile`**:\
-  The variable operational expenses are based on the capacity utilization through the variable [`:cap_use`](@extref EnergyModelsBase man-opt_var-cap).
+  The variable operating expenses are based on the capacity utilization through the variable [`:cap_use`](@extref EnergyModelsBase man-opt_var-cap).
   Hence, it is directly related to the specified `input` and `output` ratios.
   The variable operating expenses can be provided as `OperationalProfile` as well.
 - **`opex_fixed::TimeProfile`**:\

--- a/docs/src/nodes/sink/loadshiftingnode.md
+++ b/docs/src/nodes/sink/loadshiftingnode.md
@@ -58,7 +58,7 @@ with square brackets, while functions are represented as
 
 ``func\_example(index_1, index_2)``
 
-with paranthesis.
+with parantheses.
 
 ### [Variables](@id nodes-loadshiftingnode-math-var)
 

--- a/docs/src/nodes/sink/multipleinputsink.md
+++ b/docs/src/nodes/sink/multipleinputsink.md
@@ -42,7 +42,7 @@ with square brackets, while functions are represented as
 
 ``func\_example(index_1, index_2)``
 
-with paranthesis.
+with parantheses.
 
 ### [Variables](@id nodes-mul_in_sink-math-var)
 

--- a/docs/src/nodes/sink/multipleinputsinkstrat.md
+++ b/docs/src/nodes/sink/multipleinputsinkstrat.md
@@ -67,7 +67,7 @@ with square brackets, while functions are represented as
 
 ``func\_example(index_1, index_2)``
 
-with paranthesis.
+with parantheses.
 
 ### [Variables](@id nodes-mul_in_sink_strat-math-var)
 

--- a/docs/src/nodes/sink/perioddemand.md
+++ b/docs/src/nodes/sink/perioddemand.md
@@ -84,7 +84,7 @@ with square brackets, while functions are represented as
 
 ``func\_example(index_1, index_2)``
 
-with paranthesis.
+with parantheses.
 
 ### [Variables](@id nodes-perioddemandsink-math-var)
 

--- a/docs/src/nodes/source/inflexiblesource.md
+++ b/docs/src/nodes/source/inflexiblesource.md
@@ -22,7 +22,7 @@ The [`InflexibleSource`](@ref) has the same standard fields as the [`RefSource`]
   If the node should contain investments through the application of [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/stable/), it is important to note that you can only use `FixedProfile` or `StrategicProfile` for the capacity, but not `RepresentativeProfile` or `OperationalProfile`.
   In addition, all values have to be non-negative.
 - **`opex_var::TimeProfile`**:\
-  The variable operational expenses are based on the capacity utilization through the variable [`:cap_use`](@extref EnergyModelsBase man-opt_var-cap).
+  The variable operating expenses are based on the capacity utilization through the variable [`:cap_use`](@extref EnergyModelsBase man-opt_var-cap).
   Hence, it is directly related to the specified `output` ratios.
   The variable operating expenses can be provided as `OperationalProfile` as well.
 - **`opex_fixed::TimeProfile`**:\
@@ -59,7 +59,7 @@ with square brackets, while functions are represented as
 
 ``func\_example(index_1, index_2)``
 
-with paranthesis.
+with parantheses.
 
 ### [Variables](@id nodes-inflexiblesource-math-var)
 

--- a/docs/src/nodes/source/payasproducedppa.md
+++ b/docs/src/nodes/source/payasproducedppa.md
@@ -24,7 +24,7 @@ The fields of a [`PayAsProducedPPA`](@ref) are:
   In addition, all values should be in the range ``[0, 1]``.
 
 - **`opex_var::TimeProfile`**:\
-  The variable operational expenses are based on the capacity utilization through the variable `:cap_use`.
+  The variable operating expenses are based on the capacity utilization through the variable `:cap_use`.
   Hence, they are directly related to the specified `output` ratios.
   The variable operating expenses can be provided as `OperationalProfile` as well.
 
@@ -55,7 +55,7 @@ with square brackets, while functions are represented as
 
 ``func\_example(index_1, index_2)``
 
-with paranthesis.
+with parantheses.
 
 ### [Variables](@id nodes-payasproducedppa-math-var)
 
@@ -100,8 +100,8 @@ These standard constraints are:
   profile(n, t) \times \texttt{cap\_inst}[n, t]
   ```
 
-
 - `constraints_capacity_installed`:
+
   ```math
   \texttt{cap\_inst}[n, t] = capacity(n, t)
   ```
@@ -111,6 +111,7 @@ These standard constraints are:
       Nodes with investments are then no longer constrained by the parameter capacity.
 
 - `constraints_flow_out`:
+
   ```math
   \texttt{flow\_out}[n, t, p] =
   outputs(n, p) \times \texttt{cap\_use}[n, t]
@@ -118,6 +119,7 @@ These standard constraints are:
   ```
 
 - `constraints_opex_fixed`:
+
   ```math
   \texttt{opex\_fixed}[n, t_{inv}] = opex\_fixed(n, t_{inv}) \times \texttt{cap\_inst}[n, first(t_{inv})]
   ```

--- a/docs/src/nodes/storage/storageefficiency.md
+++ b/docs/src/nodes/storage/storageefficiency.md
@@ -47,7 +47,7 @@ with square brackets, while functions are represented as
 
 ``func\_example(index_1, index_2)``
 
-with paranthesis.
+with parantheses.
 
 ### [Variables](@id nodes-stor_eff-math-var)
 

--- a/examples/flexible_demand.jl
+++ b/examples/flexible_demand.jl
@@ -65,10 +65,10 @@ line = MinUpDownTimeNode(
     FixedProfile(0),
     Dict(Power => 1),
     Dict(Product => 1),
-    min_up_time, # minUpTime
-    min_down_time, # minDownTime
-    50, # minCapacity
-    300, # maxCapacity
+    min_up_time, # min_time_up
+    min_down_time, # min_time_down
+    50, # load_min
+    300, # load_max
     [],
 )
 

--- a/examples/flexible_demand.jl
+++ b/examples/flexible_demand.jl
@@ -69,7 +69,6 @@ line = MinUpDownTimeNode(
     min_down_time, # min_time_down
     50, # load_min
     300, # load_max
-    [],
 )
 
 # Define the simple energy system

--- a/src/link/datastructures.jl
+++ b/src/link/datastructures.jl
@@ -124,7 +124,7 @@ EMB.capacity(l::CapacityCostLink, t) = l.cap[t]
 """
     EMB.has_opex(l::CapacityCostLink)
 
-A `CapacityCostLink` `l` has operational expenses.
+A `CapacityCostLink` `l` has operating expenses.
 """
 EMB.has_opex(l::CapacityCostLink) = true
 

--- a/src/network/checks.jl
+++ b/src/network/checks.jl
@@ -1,11 +1,22 @@
 """
     EMB.check_node(n::MinUpDownTimeNode, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
-This method checks that a `MinUpDownTimeNode` node is valid.
+This method checks that a [`MinUpDownTimeNode`](@ref) node is valid.
+
+It reuses the standard checks of a `NetworkNode` node through calling the function
+[`EMB.check_node_default`](@extref EnergyModelsBase.check_node_default), but adds an
+additional check on the data.
 
 ## Checks
- - The minimum capacity must be greater than zero.
- - The minimum capacity must not be larger than maximum capacity.
+- The field `cap` is required to be non-negative.
+- The value of the field `fixed_opex` is required to be non-negative and
+  accessible through a `StrategicPeriod` as outlined in the function
+  [`EMB.check_fixed_opex()`](@extref EnergyModelsBase.check_fixed_opex).
+- The values of the dictionary `input` are required to be non-negative.
+- The values of the dictionary `output` are required to be non-negative.
+
+ - The field `load_min` is required to be greater than zero.
+ - The field `load_min` is required to be not larger than the field `load_max`.
 """
 function EMB.check_node(
     n::MinUpDownTimeNode,
@@ -13,16 +24,16 @@ function EMB.check_node(
     modeltype::EnergyModel,
     check_timeprofiles::Bool,
 )
-    # EMB.check_node_default(n, 𝒯, modeltype, check_timeprofiles)
+    EMB.check_node_default(n, 𝒯, modeltype, check_timeprofiles)
 
     # We need the minimum capacity to be greater than zero.
     @assert_or_log(
-        n.minCapacity > 0,
+        n.load_min > 0,
         "The minimum capacity must be greater than zero."
     )
 
     @assert_or_log(
-        n.minCapacity <= n.maxCapacity,
+        n.load_min ≤ n.load_max,
         "The minimum capacity must not be larger than maximum capacity."
     )
 end

--- a/src/network/constraint_functions.jl
+++ b/src/network/constraint_functions.jl
@@ -24,21 +24,21 @@ function EMB.constraints_capacity(
     𝒯::TimeStructure,
     modeltype::EnergyModel,
 )
+    # Extract the strategic time structure
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-    sps = collect(𝒯ᴵⁿᵛ)
 
-    for sp ∈ sps
-        ops = collect(sp) #array of al operational periodes
+    for t_inv ∈ 𝒯ᴵⁿᵛ
+        ops = collect(t_inv) #array of al operational periodes
 
-        N_h = n.minDownTime #min down time in the tinme unit used in the case
-        M_h = n.minUpTime
-        durations = [duration(t) for t ∈ ops]
+        N_h = n.min_time_down #min down time in the tinme unit used in the case
+        M_h = n.min_time_up
+        durations = [duration(t) for t ∈ t_inv]
 
-        N_arr = zeros(length(ops))
-        M_arr = zeros(length(ops))
+        N_arr = zeros(length(t_inv))
+        M_arr = zeros(length(t_inv))
 
-        for j ∈ 1:length(ops)
-            sum_duration_N = durations[j]
+        for (j, t) ∈ enumerate(t_inv)
+            sum_duration_N = duration(t)
             count = 1
             while sum_duration_N < N_h
                 sum_duration_N += circshift(durations, -count)[j]
@@ -46,7 +46,7 @@ function EMB.constraints_capacity(
             end
             N_arr[j] = count
             count = 1
-            sum_duration_M = durations[j]
+            sum_duration_M = duration(t)
             while sum_duration_M < M_h
                 sum_duration_M += circshift(durations, -count)[j]
                 count += 1
@@ -54,12 +54,11 @@ function EMB.constraints_capacity(
             M_arr[j] = count
         end
 
-        min_cap = n.minCapacity
-        max_cap = n.maxCapacity
-        for i ∈ 1:length(ops) # i from 1 to number of operational periodes
+        min_cap = n.load_min
+        max_cap = n.load_max
+        for (i, t) ∈ enumerate(t_inv) # i from 1 to number of operational periodes
             M = Int(M_arr[i])
             N = Int(N_arr[i])
-            t = ops[i]
 
             @constraint(
                 m,

--- a/src/network/datastructures.jl
+++ b/src/network/datastructures.jl
@@ -1,12 +1,12 @@
 """
-    UnitCommitmentNode{} <: EMB.NetworkNode
+    abstract type UnitCommitmentNode{} <: EMB.NetworkNode
 
 Abstract type for unit commitment nodes.
 """
 abstract type UnitCommitmentNode{} <: EMB.NetworkNode end
 
 """
-    MinUpDownTimeNode{} <: UnitCommitmentNode
+    struct MinUpDownTimeNode <: UnitCommitmentNode
 
 `MinUpDownTimeNode` is a specialized [`NetworkNode`](@extref EnergyModelsBase
 nodes-network_node) type that introduces unit commitment logic including minimum
@@ -35,7 +35,7 @@ constraints.
 - **`data::Vector{Data}`** is the additional data (*e.g.*, for investments).
   The field `data` is conditional through usage of a constructor.
 """
-struct MinUpDownTimeNode{} <: UnitCommitmentNode
+struct MinUpDownTimeNode <: UnitCommitmentNode
     id::Any
     cap::TimeProfile
     opex_var::TimeProfile
@@ -76,7 +76,7 @@ function MinUpDownTimeNode(
 end
 
 """
-    ActivationCostNode{} <: UnitCommitmentNode
+    struct ActivationCostNode <: UnitCommitmentNode
 
 `ActivationCostNode` is a specialized [`NetworkNode`](@extref EnergyModelsBase
 nodes-network_node) that introduces unit commitment logic with additional fuel
@@ -101,7 +101,7 @@ extra input when switching on, such as combustion turbines or thermal boilers.
 - **`data::Vector{Data}`** is the additional data (*e.g.*, for investments).
   The field `data` is conditional through usage of a constructor.
 """
-struct ActivationCostNode{} <: UnitCommitmentNode
+struct ActivationCostNode <: UnitCommitmentNode
     id::Any
     cap::TimeProfile
     opex_var::TimeProfile
@@ -149,7 +149,7 @@ function activation_consumption(n::ActivationCostNode, p::Resource)
 end
 
 """
-    LimitedFlexibleInput <: NetworkNode
+    struct LimitedFlexibleInput <: NetworkNode
 
 A `LimitedFlexibleInput` node.
 The `LimitedFlexibleInput` utilizes a linear, time independent conversion rate of the `input`
@@ -201,7 +201,7 @@ limits(n::LimitedFlexibleInput, p::Resource) = n.limit[p]
 limits(n::LimitedFlexibleInput) = collect(keys(n.limit))
 
 """
-    Combustion <: NetworkNode
+    struct Combustion <: NetworkNode
 
 A `Combustion` node.
 The `Combustion` is similar to [`LimitedFlexibleInput`](@ref)s but requires energy balances
@@ -270,7 +270,7 @@ Returns the heat residual resource of a [`Combustion`](@ref) node `n`.
 heat_resource(n::Combustion) = n.heat_res
 
 """
-    FlexibleOutput <: NetworkNode
+    struct FlexibleOutput <: NetworkNode
 
 A `FlexibleOutput` node.
 

--- a/src/network/datastructures.jl
+++ b/src/network/datastructures.jl
@@ -25,14 +25,14 @@ constraints.
   with conversion value `Real`.
 - **`output::Dict{<:Resource,<:Real}`** are the generated [`Resource`](@extref EnergyModelsBase.Resource)s
   with conversion value `Real`.
-- **`minUpTime::Real`** is the minimum number of operational periods the unit must remain on
+- **`min_time_up::Real`** is the minimum number of operational periods the unit must remain on
   after being started.
-- **`minDownTime::Real`** is the minimum number of operational periods the unit must remain
+- **`min_time_down::Real`** is the minimum number of operational periods the unit must remain
   off after being stopped.
-- **`minCapacity::Real`** is the minimum power output when the unit is on.
-- **`maxCapacity::Real`** is the maximum power output when the unit is on
+- **`load_min::Real`** is the minimum capacity output when the unit is on.
+- **`load_max::Real`** is the maximum capacity output when the unit is on
   (usually aligned with `cap`).
-- **`data::Vector{Data}`** is the additional data (*e.g.*, for investments).
+- **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments).
   The field `data` is conditional through usage of a constructor.
 """
 struct MinUpDownTimeNode <: UnitCommitmentNode
@@ -42,11 +42,11 @@ struct MinUpDownTimeNode <: UnitCommitmentNode
     opex_fixed::TimeProfile
     input::Dict{Resource,Real}
     output::Dict{Resource,Real}
-    minUpTime::Real #number of operational periodes
-    minDownTime::Real  #number of operational periodes
-    minCapacity::Real
-    maxCapacity::Real
-    data::Array{Data}
+    min_time_up::Real #number of operational periodes
+    min_time_down::Real  #number of operational periodes
+    load_min::Real
+    load_max::Real
+    data::Vector{<:ExtensionData}
 end
 function MinUpDownTimeNode(
     id,
@@ -55,10 +55,10 @@ function MinUpDownTimeNode(
     opex_fixed::TimeProfile,
     input::Dict{<:Resource,<:Real},
     output::Dict{<:Resource,<:Real},
-    minUpTime::Real,
-    minDownTime::Real,
-    minCapacity::Real,
-    maxCapacity::Real,
+    min_time_up::Real,
+    min_time_down::Real,
+    load_min::Real,
+    load_max::Real,
 )
     return MinUpDownTimeNode(
         id,
@@ -67,10 +67,10 @@ function MinUpDownTimeNode(
         opex_fixed,
         input,
         output,
-        minUpTime,
-        minDownTime,
-        minCapacity,
-        maxCapacity,
+        min_time_up,
+        min_time_down,
+        load_min,
+        load_max,
         Data[],
     )
 end
@@ -80,7 +80,7 @@ end
 
 `ActivationCostNode` is a specialized [`NetworkNode`](@extref EnergyModelsBase
 nodes-network_node) that introduces unit commitment logic with additional fuel
-or resource costs incurred upon startup.  It models technologies that consume
+or resource costs incurred upon startup. It models technologies that consume
 extra input when switching on, such as combustion turbines or thermal boilers.
 
 # Fields

--- a/src/sink/datastructures.jl
+++ b/src/sink/datastructures.jl
@@ -210,7 +210,7 @@ function ContinuousMultipleInputSinkStrat(
 end
 
 """
-    LoadShiftingNode <: EMB.Sink
+    struct LoadShiftingNode <: EMB.Sink
 
 A `Sink` node where the demand can be altered by load shifting. The load
 shifting is based on the assumption that the production happens in discrete

--- a/src/source/datastructures.jl
+++ b/src/source/datastructures.jl
@@ -1,5 +1,5 @@
 """
-    PayAsProducedPPA <: AbstractNonDisRES
+    struct PayAsProducedPPA <: AbstractNonDisRES
 
 A pay-as-produced ppa energy source. It extends the existing `AbstractNonDisRES` node through
 including a constraint on the opex_var such that curtailed energy is also included in the opex.
@@ -39,9 +39,9 @@ end
     struct InflexibleSource <: EMB.Source
 
 An inflexible [`Source`](@extref EnergyModelsBase.Source) node with fixed capacity.
-The inflexible [`Source`](@extref EnergyModelsBase.Source) node represents a source with a 
+The inflexible [`Source`](@extref EnergyModelsBase.Source) node represents a source with a
 fixed capacity usage.
-Note, that if you include investments, you can only use `cap` as `TimeProfile` a 
+Note, that if you include investments, you can only use `cap` as `TimeProfile` a
 `FixedProfile` or `StrategicProfile`.
 
 # Fields
@@ -51,7 +51,7 @@ Note, that if you include investments, you can only use `cap` as `TimeProfile` a
   through the variable `:cap_use`.
 - **`opex_fixed::TimeProfile`** is the fixed operating expense per installed capacity
   through the variable `:cap_inst`.
-- **`output::Dict{<:Resource,<:Real}`** are the generated 
+- **`output::Dict{<:Resource,<:Real}`** are the generated
   [`Resource`](@extref EnergyModelsBase.Resource)s with conversion value `Real`.
 - **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments).
   The field `data` is conditional through usage of a constructor.

--- a/src/storage/datastructures.jl
+++ b/src/storage/datastructures.jl
@@ -55,7 +55,7 @@ function ElectricBattery{T}(
 end
 
 """
-    StorageEfficiency{T} <: EMB.Storage{T}
+    struct StorageEfficiency{T} <: EMB.Storage{T}
 
 A StorageEfficiency node which enables storage efficiency control compared to RefStorage{T}.
 

--- a/test/network/test_MinUpDownTimeNode.jl
+++ b/test/network/test_MinUpDownTimeNode.jl
@@ -1,49 +1,62 @@
-using EnergyModelsBase
-using EnergyModelsFlex
+# Declare the products
+power = ResourceCarrier("power", 0)
+product = ResourceCarrier("product", 0)
+CO2 = ResourceEmit("CO2", 0)
 
-using HiGHS
-using JuMP
-using Test
-using TimeStruct
-
-function create_system(line)
+function test_case_minupdown(
+    min_up = 2,
+    min_down = 2 ;
+    cap = FixedProfile(200),
+    tp_opex_var = FixedProfile(0),
+    tp_opex_fixed = FixedProfile(0),
+    inp_val = 1,
+    out_val = 1,
+    min_cap = 20,
+    max_cap = 200,
+)
     𝒯 = TwoLevel(1, 1, SimpleTimes(7 * 24, 1))
-
-    Power = ResourceCarrier("Power", 0)
-    Product = ResourceCarrier("Product", 0)
-    CO2 = ResourceEmit("CO2", 0)
-    𝒫 = [Power, Product, CO2]
+    𝒫 = [power, product, CO2]
 
     day = [1, 1, 1, 1, 1, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 9, 8, 7, 6, 5, 4, 3, 2]
     el_cost = [repeat(day, 5)..., fill(0, 2 * 24)...]
 
-    grid = RefSource(
-        "grid",
+    src = RefSource(
+        "src",
         FixedProfile(1e12), # kW - virtually infinite
         OperationalProfile(el_cost),
         FixedProfile(0),
-        Dict(Power => 1),
+        Dict(power => 1),
     )
 
-    # The production can only run between 6-20 on weekdays, with capacity of 200.
+    line = MinUpDownTimeNode(
+        "line",
+        cap, # kW - installed capacity for both lines
+        tp_opex_var,
+        tp_opex_fixed,
+        Dict(power => inp_val),
+        Dict(product => out_val),
+        min_up, # min_up_time
+        min_down, # min_down_time
+        min_cap, # min_capacity
+        max_cap, # max_capacity
+    )
+
+    # The demand can only be satisfied between 6-20 on weekdays, with a capacity of 200.
     # No production on weekends.
     weekday_prod = [fill(0, 6)..., fill(200, 14)..., fill(0, 4)...]
-    @assert length(weekday_prod) == 24
     week_prod = [repeat(weekday_prod, 5)..., fill(0, 2 * 24)...]
 
-    demand = PeriodDemandSink(
+    snk = PeriodDemandSink(
         "demand_product",
-        # 24 hours per day.
-        24,
-        # Produce 1500 units per day, and nothing (0) in the weekend.
-        [fill(1500, 5)..., 0, 0],
+        24,                         # 24 hours per day
+        [fill(1500, 5)..., 0, 0],   # Demand 1500 units per day, and nothing (0) in the weekend.
         OperationalProfile(week_prod), # kW - installed capacity
         Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e8)), # € / Demand - Price for not delivering products
-        Dict(Product => 1),
+        Dict(product => 1),
     )
 
-    𝒩 = [grid, line, demand]
-    ℒ = [Direct("grid-line", grid, line), Direct("line-demand", line, demand)]
+    𝒩 = [src, line, snk]
+    ℒ = [Direct("src-line", src, line), Direct("line-snk", line, snk)]
 
     case = Case(𝒯, 𝒫, [𝒩, ℒ])
 
@@ -52,51 +65,79 @@ function create_system(line)
         Dict(CO2 => FixedProfile(100)),
         CO2,
     )
-    return case, modeltype
+    m = create_model(case, modeltype)
+
+    return m, case, modeltype
 end
 
-function create_line(min_up, min_down)
-    Power = ResourceCarrier("Power", 0)
-    Product = ResourceCarrier("Product", 0)
-    line = MinUpDownTimeNode(
-        "line",
-        FixedProfile(200), # kW - installed capacity for both lines
-        FixedProfile(0),
-        FixedProfile(0),
-        Dict(Power => 1),
-        Dict(Product => 1),
-        min_up, # minUpTime
-        min_down, # minDownTime
-        50, # minCapacity
-        200, # maxCapacity
-        [],
-    )
-    return line
+@testset "Check functions" begin
+    # Set the global to true to suppress the error message
+    EMB.TEST_ENV = true
+
+    # Default checks
+    # - EMB.check_node_default(n, 𝒯, modeltype, check_timeprofiles)
+    @test_throws AssertionError test_case_minupdown(; cap=FixedProfile(-5))
+    @test_throws AssertionError test_case_minupdown(; inp_val=-1)
+    @test_throws AssertionError test_case_minupdown(; out_val=-1)
+    @test_throws AssertionError test_case_minupdown(; tp_opex_fixed = OperationalProfile([1]))
+
+    # Introduced checks
+    # - EMB.check_node(n::MinUpDownTimeNode, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+    @test_throws AssertionError test_case_minupdown(; min_cap = 0)
+    @test_throws AssertionError test_case_minupdown(; max_cap = 0)
+
+    # Set the global to true to suppress the error message
+    EMB.TEST_ENV = false
 end
 
-@testset "check-cyclic-sequence" begin
-    # Test the MinUpDownTimeNode with different values of min_up_time and min_down_time.
-    for min_up_time ∈ 2:8
-        for min_down_time ∈ 2:8
-            line = create_line(min_up_time, min_down_time)
-            case, model = create_system(line)
+@testset "Extraction functions" begin
+    # Create the model and extract the parameters
+    tp_opex_fixed = FixedProfile(10)
+    tp_opex_var = FixedProfile(5)
+    m, case, modeltype = test_case_minupdown(; tp_opex_fixed, tp_opex_var);
+    line = get_nodes(case)[2]
+    𝒯 = get_time_struct(case)
 
-            m = EnergyModelsBase.run_model(case, model, OPTIMIZER)
+    # Test the capacity extraction functions
+    @test capacity(line) == FixedProfile(200)
+    @test all(capacity(line, t) == 200 for t ∈ 𝒯)
 
-            # Test optimal solution
-            general_tests(m)
+    # Test the opex extraction functions
+    @test opex_var(line) == FixedProfile(5)
+    @test all(opex_var(line, t) == 5 for t ∈ 𝒯)
+    @test opex_fixed(line) == FixedProfile(10)
+    @test all(opex_fixed(line, t) == 10 for t ∈ 𝒯)
 
-            line = get_nodes(case)[2]
+    # Test the input and output extraction functions
+    @test inputs(line) == [power]
+    @test inputs(line, power) == 1
+    @test outputs(line) == [product]
+    @test outputs(line, product) == 1
 
-            # Test that the minimum up time and minimum down time are at least
-            # min_up_time and min_down_time.
-            cap_use = get_values(m, :cap_use, line, get_time_struct(case))
-            check = check_cyclic_sequence(cap_use, min_up_time, min_down_time)
-            @test check
-            msg = "check-min_up_time=$min_up_time, min_down_time=$min_down_time"
-            if !check
-                @warn "Failed for: $msg"
-            end
+    # Test the data extraction function
+    @test node_data(line) == ExtensionData[]
+end
+
+@testset "Cyclic sequence" begin
+    # Test the MinUpDownTimeNode with different values of min_up and min_down.
+    for min_up ∈ 2:8, min_down ∈ 2:8
+        # Create the case and model
+        m, case, model = test_case_minupdown(min_up, min_down)
+        set_optimizer(m, OPTIMIZER)
+        optimize!(m)
+
+        # Test optimal solution
+        general_tests(m)
+        line = get_nodes(case)[2]
+
+        # Test that the minimum up time and minimum down time are at least
+        # min_up and min_down.
+        cap_use = get_values(m, :cap_use, line, get_time_struct(case))
+        check = check_cyclic_sequence(cap_use, min_up, min_down)
+        @test check
+        msg = "check-min_up=$min_up, min_down=$min_down"
+        if !check
+            @warn "Failed for: $msg"
         end
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,3 @@
-using JuMP
-
 const ATOL = 1e-7
 
 """


### PR DESCRIPTION
This PR improves the constraint description of a `MinUpDownTimeNode` and moves away from *camelCase* for the fields. In addition, it improves the tests structure by including tests for the checks and the extraction functions.

> [!IMPORTANT]  
> There will be two additional PRs before I register a new version.