### PR TITLE
Adjustments to EMI v0.9, EMB v0.10, and EMRP v0.7

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,22 @@
 # Release notes
 
-## Unversioned
+## Version 0.7.0 (2026-04-16)
 
-### Enhancements
+### Breaking changes
 
+* Adjusted to [`EnergyModelsBase` v0.10.0](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0) and [`EnergyModelsRenewableProducers` v0.7.0](https://github.com/EnergyModelsX/EnergyModelsRenewableProducers.jl/releases/tag/v0.7.0):
+  * Model worked without adjustments.
+  * Breaking change still included to maintain the possibility to do bug fixes in version 0.1.x for existing models with `EnergyModelsBase` v0.9.x.
+  * UpdMoved from `Data` to `ExtensionData` in fields and tests.
 * Improved `MinUpDownTimeNode`:
   * Rewrote the function `constraints_capacity` based on core functionality.
   * Updated the test set to identify all potential problems with the node.
+  * Renamed field names of the type.
 
+### Additional changes
+
+* Updated CI versions.
+* Fixed errors in the documentation.
 
 ## Version 0.2.11 (2026-02-16)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,13 @@
 # Release notes
 
-## Version 0.7.0 (2026-04-16)
+## Version 0.3.0 (2026-04-16)
 
 ### Breaking changes
 
 * Adjusted to [`EnergyModelsBase` v0.10.0](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0) and [`EnergyModelsRenewableProducers` v0.7.0](https://github.com/EnergyModelsX/EnergyModelsRenewableProducers.jl/releases/tag/v0.7.0):
-  * Model worked without adjustments.
+  * Breaking change required as early retirement is now allowed.
+  * Early retirement changes the model behavior.
+  * Model worked without adjustments except for compatibility updates.
   * Breaking change still included to maintain the possibility to do bug fixes in version 0.1.x for existing models with `EnergyModelsBase` v0.9.x.
   * UpdMoved from `Data` to `ExtensionData` in fields and tests.
 * Improved `MinUpDownTimeNode`:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsFlex"
 uuid = "a81b9388-333d-4b63-81f2-910b060b544c"
 authors = ["Sigrid Aunsmo, Sigmund Eggen Holm, Jon Vegard Venås, and Per Åslid"]
-version = "0.2.11"
+version = "0.3.0"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
@@ -10,8 +10,8 @@ JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"
 
 [compat]
-EnergyModelsBase = "0.9"
-EnergyModelsRenewableProducers = "0.6.5"
+EnergyModelsBase = "0.10"
+EnergyModelsRenewableProducers = "0.7"
 JuMP = "1.23"
 TimeStruct = "0.9"
 julia = "1.10"

--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@
 > The different node types are partly experimental.
 > They have furthermore some limitations with respect to the chosen `TimeStructure` or whether they are able to handle investments.
 > As a consequence, it is advised to read the documentation for each node to identify their usefulness.
+> Is is planned to removesome nodes and rewrite the behaviour of other nodes to improve their flexibility.
 >
-> The initial version is based on [`EnergyModelsBase` v0.8](https://energymodelsx.github.io/EnergyModelsBase.jl/v0.8/).
-> It is planned to update the model in the near future to support the latest version of `EnergyModelsBase`.
-> This update may include the removal of some nodes and a rewrite of the behaviour of the different nodes.
+> Version 0.2.8 is based on [`EnergyModelsBase` v0.8](https://energymodelsx.github.io/EnergyModelsBase.jl/v0.8/) while version 0.2.9 is adding support for [`EnergyModelsBase` v0.9](https://energymodelsx.github.io/EnergyModelsBase.jl/v0.9/).
 
 ## Usage
 

--- a/docs/src/nodes/network/activationcostnode.md
+++ b/docs/src/nodes/network/activationcostnode.md
@@ -37,7 +37,7 @@ The standard fields are given as:
   CO₂ cannot be directly specified, *i.e.*, you cannot specify a ratio.
   If you use [`CaptureData`](@extref EnergyModelsBase.CaptureData), it is however necessary to specify CO₂ as output, although the ratio is not important.\
   All values have to be non-negative.
-- **`data::Vector{Data}`**:\
+- **`data::Vector{<:ExtensionData}`**:\
   An entry for providing additional data to the model.
   In the current version, it is used for providing `EmissionsData`.
 

--- a/docs/src/nodes/network/combustion.md
+++ b/docs/src/nodes/network/combustion.md
@@ -34,7 +34,7 @@ The standard fields are given as:
   CO₂ cannot be directly specified, *i.e.*, you cannot specify a ratio.
   If you use [`CaptureData`](@extref EnergyModelsBase.CaptureData), it is however necessary to specify CO₂ as output, although the ratio is not important.\
   All values have to be non-negative.
-- **`data::Vector{<:Data}`**:\
+- **`data::Vector{<:ExtensionData}`**:\
   An entry for providing additional data to the model.
   In the current version, it is used for both providing `EmissionsData` and additional investment data when [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) is used.
 

--- a/docs/src/nodes/network/limitedflexibleinput.md
+++ b/docs/src/nodes/network/limitedflexibleinput.md
@@ -28,7 +28,7 @@ The standard fields are given as:
   CO₂ cannot be directly specified, *i.e.*, you cannot specify a ratio.
   If you use [`CaptureData`](@extref EnergyModelsBase.CaptureData), it is however necessary to specify CO₂ as output, although the ratio is not important.\
   All values have to be non-negative.
-- **`data::Vector{<:Data}`**:\
+- **`data::Vector{<:ExtensionData}`**:\
   An entry for providing additional data to the model.
   In the current version, it is used for both providing `EmissionsData` and additional investment data when [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) is used.
 

--- a/docs/src/nodes/network/minupdowntimenode.md
+++ b/docs/src/nodes/network/minupdowntimenode.md
@@ -33,7 +33,7 @@ The standard fields are given as:
   CO₂ cannot be directly specified, *i.e.*, you cannot specify a ratio.
   If you use [`CaptureData`](@extref EnergyModelsBase.CaptureData), it is however necessary to specify CO₂ as output, although the ratio is not important.\
   All values have to be non-negative.
-- **`data::Vector{<:Data}`**:\
+- **`data::Vector{<:ExtensionData}`**:\
   Optional metadata (*e.g.*, emissions or investment data). This is initialized to an empty array by default.
 
   !!! note "Constructor for `MinUpDownTimeNode`"

--- a/docs/src/nodes/sink/loadshiftingnode.md
+++ b/docs/src/nodes/sink/loadshiftingnode.md
@@ -38,7 +38,7 @@ The fields of a [`LoadShiftingNode`](@ref) are:
   The magnitude of demand shifted per period in a batch.
 - **`load_shift_times_per_period::Int`**:\
   Number of time steps per shift group in which shifts may occur.
-- **`data::Vector{Data}`**:\
+- **`data::Vector{<:ExtensionData}`**:\
   Optional metadata (e.g., emissions, investment data).
 
 !!! warning

--- a/docs/src/nodes/sink/multipleinputsink.md
+++ b/docs/src/nodes/sink/multipleinputsink.md
@@ -22,7 +22,7 @@ The fields of a [`MultipleInputSink`](@ref) node are given as:
 - **`input::Dict{<:Resource,<:Real}`**:\
   The field `input` includes [`Resource`](@extref EnergyModelsBase.Resource)s with their corresponding conversion factors as dictionaries.\
   All values have to be non-negative.
-- **`data::Vector{Data}`**:\
+- **`data::Vector{<:ExtensionData}`**:\
   An entry for providing additional data to the model.
   In the current version, it is used for both providing `EmissionsData` and additional investment data when [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) is used.
   !!! note "Included constructor"

--- a/docs/src/nodes/sink/multipleinputsinkstrat.md
+++ b/docs/src/nodes/sink/multipleinputsinkstrat.md
@@ -44,7 +44,7 @@ These fields are:
 - **`input::Dict{<:Resource,<:Real}`**:\
   The field `input` includes [`Resource`](@extref EnergyModelsBase.Resource)s with their corresponding conversion factors as dictionaries.\
   All values have to be non-negative.
-- **`data::Vector{Data}`**:\
+- **`data::Vector{<:ExtensionData}`**:\
   An entry for providing additional data to the model.
   In the current version, it is used for both providing `EmissionsData` and additional investment data when [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) is used.
   !!! note "Included constructor"

--- a/docs/src/nodes/sink/perioddemand.md
+++ b/docs/src/nodes/sink/perioddemand.md
@@ -43,7 +43,7 @@ The standard fields are given as:
 - **`input::Dict{<:Resource,<:Real}`**:\
   The field `input` includes [`Resource`](@extref EnergyModelsBase.Resource)s with their corresponding conversion factors as dictionaries.\
   All values have to be non-negative.
-- **`data::Vector{Data}`**:\
+- **`data::Vector{<:ExtensionData}`**:\
   An entry for providing additional data to the model.
   In the current version, it is used for both providing `EmissionsData` and additional investment data when [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) is used.
   !!! note "Included constructor"

--- a/docs/src/nodes/source/inflexiblesource.md
+++ b/docs/src/nodes/source/inflexiblesource.md
@@ -33,7 +33,7 @@ The [`InflexibleSource`](@ref) has the same standard fields as the [`RefSource`]
   The field `output` includes [`Resource`](@extref EnergyModelsBase.Resource)s with their corresponding conversion factors as dictionaries.
   In the case of a non-dispatchable renewable energy source, `output` should always include your *electricity* resource. In practice, you should use a value of 1.\
   All values have to be non-negative.
-- **`data::Vector{Data}`**:\
+- **`data::Vector{<:ExtensionData}`**:\
   An entry for providing additional data to the model.
   In the current version, it is only relevant for additional investment data when [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/stable/) is used.
   !!! note

--- a/docs/src/nodes/source/payasproducedppa.md
+++ b/docs/src/nodes/source/payasproducedppa.md
@@ -38,7 +38,7 @@ The fields of a [`PayAsProducedPPA`](@ref) are:
   In the case of a pay-as-produced PPA energy source, `output` should include your *electricity* resource.
   In practice, you should use a value of 1.
 
-- **`data::Vector{Data}`**:
+- **`data::Vector{<:ExtensionData}`**:
   An entry for providing additional data to the model.
   In the current version, it is only relevant for additional investment data when [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/stable/) is used.
   !!! note "Constructor for `PayAsProducedPPA`"

--- a/docs/src/nodes/storage/storageefficiency.md
+++ b/docs/src/nodes/storage/storageefficiency.md
@@ -30,7 +30,7 @@ The fields of a [`StorageEfficiency`](@ref) are:
 - **`input::Dict{<:Resource,<:Real}`** and **`output::Dict{<:Resource,<:Real}`**:\
   Both fields describe the `input` and `output` [`Resource`](@extref EnergyModelsBase.Resource)s with their corresponding conversion factors as dictionaries.
   The stored [`Resource`](@extref EnergyModelsBase.Resource) (outlined above) must be included to create the linking variables.
-- **`data::Vector{<:Data}`**:\
+- **`data::Vector{<:ExtensionData}`**:\
   An entry for providing additional data to the model.
   In the current version, it is used for additional investment data when [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) is used.
   !!! note "Constructor for `StorageEfficiency`"

--- a/src/network/datastructures.jl
+++ b/src/network/datastructures.jl
@@ -71,7 +71,7 @@ function MinUpDownTimeNode(
         min_time_down,
         load_min,
         load_max,
-        Data[],
+        ExtensionData[],
     )
 end
 
@@ -98,7 +98,7 @@ extra input when switching on, such as combustion turbines or thermal boilers.
   activation logic in customized formulations).
 - **`activation_consumption::Dict{<:Resource,<:Real}`** are the additional input resources
   required when the unit switches on with their absolute demand.
-- **`data::Vector{Data}`** is the additional data (*e.g.*, for investments).
+- **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments).
   The field `data` is conditional through usage of a constructor.
 """
 struct ActivationCostNode <: UnitCommitmentNode
@@ -110,7 +110,7 @@ struct ActivationCostNode <: UnitCommitmentNode
     output::Dict{Resource,Real}
     activation_time::Real
     activation_consumption::Dict{Resource,Real}
-    data::Array{Data}
+    data::Vector{<:ExtensionData}
 end
 function ActivationCostNode(
     id,
@@ -131,7 +131,7 @@ function ActivationCostNode(
         output,
         activation_time,
         activation_consumption,
-        Data[],
+        ExtensionData[],
     )
 end
 
@@ -173,7 +173,7 @@ introduces a `limit` on the fraction a given resource can contribute to the tota
   with conversion value `Real`.
 - **`output::Dict{<:Resource,<:Real}`** are the generated [`Resource`](@extref EnergyModelsBase.Resource)s
   with conversion value `Real`.
-- **`data::Vector{Data}`** is the additional data (*e.g.*, for investments).
+- **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments).
   The field `data` is conditional through usage of a constructor.
 """
 struct LimitedFlexibleInput <: NetworkNode
@@ -184,7 +184,7 @@ struct LimitedFlexibleInput <: NetworkNode
     limit::Dict{<:Resource,<:Real}
     input::Dict{<:Resource,<:Real}
     output::Dict{<:Resource,<:Real}
-    data::Vector{<:Data}
+    data::Vector{<:ExtensionData}
 end
 function LimitedFlexibleInput(
     id,
@@ -195,7 +195,7 @@ function LimitedFlexibleInput(
     input::Dict{<:Resource,<:Real},
     output::Dict{<:Resource,<:Real},
 )
-    return LimitedFlexibleInput(id, cap, opex_var, opex_fixed, limit, input, output, Data[])
+    return LimitedFlexibleInput(id, cap, opex_var, opex_fixed, limit, input, output, ExtensionData[])
 end
 limits(n::LimitedFlexibleInput, p::Resource) = n.limit[p]
 limits(n::LimitedFlexibleInput) = collect(keys(n.limit))
@@ -221,7 +221,7 @@ in the sense that the output `heat_res` captures the lost energy.
   with conversion value `Real`.
 - **`output::Dict{<:Resource,<:Real}`** are the generated [`Resource`](@extref EnergyModelsBase.Resource)s
   with conversion value `Real`.
-- **`data::Vector{Data}`** is the additional data (*e.g.*, for investments).
+- **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments).
   The field `data` is conditional through usage of a constructor.
 """
 struct Combustion <: NetworkNode
@@ -233,7 +233,7 @@ struct Combustion <: NetworkNode
     heat_res::Resource
     input::Dict{<:Resource,<:Real}
     output::Dict{<:Resource,<:Real}
-    data::Vector{<:Data}
+    data::Vector{<:ExtensionData}
 end
 function Combustion(
     id,
@@ -245,7 +245,7 @@ function Combustion(
     input::Dict{<:Resource,<:Real},
     output::Dict{<:Resource,<:Real},
 )
-    return Combustion(id, cap, opex_var, opex_fixed, limit, heat_res, input, output, Data[])
+    return Combustion(id, cap, opex_var, opex_fixed, limit, heat_res, input, output, ExtensionData[])
 end
 
 """
@@ -289,7 +289,7 @@ by the sum of these.
   with conversion value `Real`.
 - **`output::Dict{<:Resource,<:Real}`** are the generated [`Resource`](@extref EnergyModelsBase.Resource)s
   with conversion value `Real`.
-- **`data::Vector{Data}`** is the additional data (*e.g.*, for investments).
+- **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments).
   The field `data` is conditional through usage of a constructor.
 """
 struct FlexibleOutput <: EMB.NetworkNode
@@ -299,7 +299,7 @@ struct FlexibleOutput <: EMB.NetworkNode
     opex_fixed::TimeProfile
     input::Dict{<:Resource,<:Real}
     output::Dict{<:Resource,<:Real}
-    data::Vector{Data}
+    data::Vector{<:ExtensionData}
 end
 function FlexibleOutput(
     id::Any,
@@ -309,5 +309,5 @@ function FlexibleOutput(
     input::Dict{<:Resource,<:Real},
     output::Dict{<:Resource,<:Real},
 )
-    return FlexibleOutput(id, cap, opex_var, opex_fixed, input, output, Data[])
+    return FlexibleOutput(id, cap, opex_var, opex_fixed, input, output, ExtensionData[])
 end

--- a/src/sink/datastructures.jl
+++ b/src/sink/datastructures.jl
@@ -41,7 +41,7 @@ each operational period.
   dictionary requires the  fields `:surplus` and `:deficit`.
 - **`input::Dict{<:Resource,<:Real}`** are the input [`Resource`](@extref EnergyModelsBase.Resource)s
   with conversion value `Real`.
-- **`data::Vector{Data}`** is the additional data (*e.g.*, for investments). The field `data`
+- **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments). The field `data`
   is conditional through usage of a constructor.
 """
 struct PeriodDemandSink <: AbstractPeriodDemandSink
@@ -51,7 +51,7 @@ struct PeriodDemandSink <: AbstractPeriodDemandSink
     cap::TimeProfile
     penalty::Dict{Symbol,<:TimeProfile}
     input::Dict{<:Resource,<:Real}
-    data::Array{Data}
+    data::Vector{<:ExtensionData}
 end
 function PeriodDemandSink(
     id,
@@ -61,7 +61,7 @@ function PeriodDemandSink(
     penalty::Dict{Symbol,<:TimeProfile},
     input::Dict{<:Resource,<:Real},
 )
-    PeriodDemandSink(id, period_length, period_demand, cap, penalty, input, Data[])
+    PeriodDemandSink(id, period_length, period_demand, cap, penalty, input, ExtensionData[])
 end
 
 """
@@ -113,7 +113,7 @@ independent of each other.
   dictionary requires the  fields `:surplus` and `:deficit`.
 - **`input::Dict{<:Resource,<:Real}`** are the input [`Resource`](@extref EnergyModelsBase.Resource)s
   with conversion value `Real`.
-- **`data::Vector{<:Data}`** is the additional data (*e.g.*, for investments).
+- **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments).
   The field `data` is conditional through usage of a constructor.
 """
 struct MultipleInputSink <: AbstractMultipleInputSink
@@ -121,7 +121,7 @@ struct MultipleInputSink <: AbstractMultipleInputSink
     cap::TimeProfile
     penalty::Dict{Symbol,<:TimeProfile}
     input::Dict{<:Resource,<:Real}
-    data::Vector{<:Data}
+    data::Vector{<:ExtensionData}
 end
 function MultipleInputSink(
     id,
@@ -129,7 +129,7 @@ function MultipleInputSink(
     penalty::Dict{Symbol,<:TimeProfile},
     input::Dict{<:Resource,<:Real},
 )
-    return MultipleInputSink(id, cap, penalty, input, Data[])
+    return MultipleInputSink(id, cap, penalty, input, ExtensionData[])
 end
 
 """
@@ -147,7 +147,7 @@ carriers can satisfy the demand, but only one resource at the time (for each str
   dictionary requires the  fields `:surplus` and `:deficit`.
 - **`input::Dict{<:Resource,<:Real}`** are the input [`Resource`](@extref EnergyModelsBase.Resource)s
   with conversion value `Real`.
-- **`data::Vector{<:Data}`** is the additional data (*e.g.*, for investments).
+- **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments).
   The field `data` is conditional through usage of a constructor.
 
 !!! warning "Investment options"
@@ -159,7 +159,7 @@ struct BinaryMultipleInputSinkStrat <: AbstractMultipleInputSinkStrat
     cap::TimeProfile
     penalty::Dict{Symbol,<:TimeProfile}
     input::Dict{<:Resource,<:Real}
-    data::Vector{<:Data}
+    data::Vector{<:ExtensionData}
 end
 function BinaryMultipleInputSinkStrat(
     id,
@@ -167,7 +167,7 @@ function BinaryMultipleInputSinkStrat(
     penalty::Dict{Symbol,<:TimeProfile},
     input::Dict{<:Resource,<:Real},
 )
-    return BinaryMultipleInputSinkStrat(id, cap, penalty, input, Data[])
+    return BinaryMultipleInputSinkStrat(id, cap, penalty, input, ExtensionData[])
 end
 
 """
@@ -186,7 +186,7 @@ are given as a variable to be optimized (for each strategic period).
   dictionary requires the  fields `:surplus` and `:deficit`.
 - **`input::Dict{<:Resource,<:Real}`** are the input [`Resource`](@extref EnergyModelsBase.Resource)s
   with conversion value `Real`.
-- **`data::Vector{<:Data}`** is the additional data (*e.g.*, for investments).
+- **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments).
   The field `data` is conditional through usage of a constructor.
 
 !!! warning "Investment options"
@@ -198,7 +198,7 @@ struct ContinuousMultipleInputSinkStrat <: AbstractMultipleInputSinkStrat
     cap::TimeProfile
     penalty::Dict{Symbol,<:TimeProfile}
     input::Dict{<:Resource,<:Real}
-    data::Vector{<:Data}
+    data::Vector{<:ExtensionData}
 end
 function ContinuousMultipleInputSinkStrat(
     id,
@@ -206,7 +206,7 @@ function ContinuousMultipleInputSinkStrat(
     penalty::Dict{Symbol,<:TimeProfile},
     input::Dict{<:Resource,<:Real},
 )
-    return ContinuousMultipleInputSinkStrat(id, cap, penalty, input, Data[])
+    return ContinuousMultipleInputSinkStrat(id, cap, penalty, input, ExtensionData[])
 end
 
 """
@@ -242,7 +242,7 @@ shifted within this group.
 - **`load_shift_duration::Int`** the number of operational periods in each load shift.
 - **`load_shift_magnitude::Real`** the magnitude for each operational period that is load shifted.
 - **`load_shift_times_per_period::Int`** the number of timeslots (from the loadshifttimes) that can be shifted.
-- **`data::Vector{Data}`** is the additional data (*e.g.*, for investments). The field `data`
+- **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments). The field `data`
   is conditional through usage of a constructor.
 """
 struct LoadShiftingNode <: EMB.Sink
@@ -255,7 +255,7 @@ struct LoadShiftingNode <: EMB.Sink
     load_shift_duration::Int
     load_shift_magnitude::Real
     load_shift_times_per_period::Int
-    data::Vector{Data}
+    data::Vector{<:ExtensionData}
 end
 function LoadShiftingNode(
     id::Any,
@@ -278,6 +278,6 @@ function LoadShiftingNode(
         load_shift_duration,
         load_shift_magnitude,
         load_shift_times_per_period,
-        Data[],
+        ExtensionData[],
     )
 end

--- a/src/source/datastructures.jl
+++ b/src/source/datastructures.jl
@@ -12,7 +12,7 @@ including a constraint on the opex_var such that curtailed energy is also includ
 - **`opex_var::TimeProfile`** is the variable operating expense per energy unit produced.
 - **`opex_fixed::TimeProfile`** is the fixed operating expense.
 - **`output::Dict{Resource, Real}`** are the generated `Resource`s, normally Power.
-- **`data::Vector{Data}`** is the additional data (*e.g.*, for investments). The field `data`
+- **`data::Vector{<:ExtensionData}`** is the additional data (*e.g.*, for investments). The field `data`
   is conditional through usage of a constructor.
 """
 struct PayAsProducedPPA <: AbstractNonDisRES
@@ -22,7 +22,7 @@ struct PayAsProducedPPA <: AbstractNonDisRES
     opex_var::TimeProfile
     opex_fixed::TimeProfile
     output::Dict{<:Resource,<:Real}
-    data::Vector{Data}
+    data::Vector{<:ExtensionData}
 end
 function PayAsProducedPPA(
     id::Any,
@@ -32,7 +32,7 @@ function PayAsProducedPPA(
     opex_fixed::TimeProfile,
     output::Dict{<:Resource,<:Real},
 )
-    return PayAsProducedPPA(id, cap, profile, opex_var, opex_fixed, output, Data[])
+    return PayAsProducedPPA(id, cap, profile, opex_var, opex_fixed, output, ExtensionData[])
 end
 
 """

--- a/src/storage/datastructures.jl
+++ b/src/storage/datastructures.jl
@@ -14,7 +14,7 @@ struct ElectricBattery{T<:EMB.StorageBehavior} <: EMB.Storage{T}
     stor_res::Resource
     input::Dict{<:Resource,<:Real}
     output::Dict{<:Resource,<:Real}
-    data::Vector{<:Data}
+    data::Vector{<:ExtensionData}
 
     function ElectricBattery{T}(
         id,
@@ -25,7 +25,7 @@ struct ElectricBattery{T<:EMB.StorageBehavior} <: EMB.Storage{T}
         stor_res::Resource,
         input::Dict{<:Resource,<:Real},
         output::Dict{<:Resource,<:Real},
-        data::Vector{<:Data}) where {T<:EMB.StorageBehavior}
+        data::Vector{<:ExtensionData}) where {T<:EMB.StorageBehavior}
         @warn "Depcrecation note: the development of ElectricBattery node is " *
               "discontinued, and the node will be removed in the next release v0.3.0."
         new{T}(id, charge, level, c_rate, coloumbic_eff, stor_res, input, output, data)
@@ -50,7 +50,7 @@ function ElectricBattery{T}(
         stor_res,
         input,
         output,
-        Data[],
+        ExtensionData[],
     )
 end
 
@@ -91,7 +91,7 @@ struct StorageEfficiency{T} <: EMB.Storage{T}
     stor_res::Resource
     input::Dict{<:Resource,<:Real}
     output::Dict{<:Resource,<:Real}
-    data::Vector{<:Data}
+    data::Vector{<:ExtensionData}
 end
 function StorageEfficiency{T}(
     id,
@@ -101,5 +101,5 @@ function StorageEfficiency{T}(
     input::Dict{<:Resource,<:Real},
     output::Dict{<:Resource,<:Real},
 ) where {T<:EMB.StorageBehavior}
-    return StorageEfficiency{T}(id, charge, level, stor_res, input, output, Data[])
+    return StorageEfficiency{T}(id, charge, level, stor_res, input, output, ExtensionData[])
 end

--- a/test/network/test_ActivationCostNode.jl
+++ b/test/network/test_ActivationCostNode.jl
@@ -93,7 +93,7 @@ end
     @test opex_fixed(act_cost_node) == FixedProfile(0)
     @test inputs(act_cost_node) == [h2, power] || inputs(act_cost_node) == [power, h2]
     @test outputs(act_cost_node) == [h2]
-    @test node_data(act_cost_node) == Data[]
+    @test node_data(act_cost_node) == ExtensionData[]
 
     # Test the EMF utility functions
     @test EMF.activation_consumption(act_cost_node) == Dict(power => 10)


### PR DESCRIPTION
This PR increases the dependency version number due to the new version to [`EnergyModelsInvestments` v0.9](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/releases/tag/v0.9.0) and the related changes in [`EnergyModelsBase` v0.10](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0) and *[`EnergyModelsRenewableProducers` v0.7](https://github.com/EnergyModelsX/EnergyModelsRenewableProducers.jl/releases/tag/v0.7.0).

The adjustments did not require any changes except for dependency updates. It is however prudent to do a major version increase to maintain the potential for bug fixes in the previous version. In addition, the behavior may change when investments are included.